### PR TITLE
Add precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+    -   id: black

--- a/Batt_Board/README.md
+++ b/Batt_Board/README.md
@@ -1,5 +1,5 @@
 # flight_controller_software
-Software for the flight controller board in the PROVES Kit. 
+Software for the flight controller board in the PROVES Kit.
 - **boot.py** This is the code that runs on boot and initializes the stack limit
 - **cdh.py** This is the code that handles all the commands. A majority of this code is pulled from the cdh file developed by Max Holliday at Stanford.
 - **code.py** This code runs the main operating system of the satellite and handles errors on a high level allowing the system to be fault tolerant

--- a/Batt_Board/code.py
+++ b/Batt_Board/code.py
@@ -1,6 +1,6 @@
 """
 In this method the PyCubed will wait a pre-allotted loiter time before proceeding to execute
-main. This loiter time is to allow for a keyboard interupt if needed. 
+main. This loiter time is to allow for a keyboard interupt if needed.
 
 Authors: Nicole Maggard and Michael Pham
 """

--- a/Batt_Board/lib/Big_Data.py
+++ b/Batt_Board/lib/Big_Data.py
@@ -1,8 +1,8 @@
 """
-This class creates an object for each face of Yearling. 
+This class creates an object for each face of Yearling.
 
 Authors: Antony Macar, Michael Pham, Nicole Maggard
-Updated July 26, 2022 
+Updated July 26, 2022
 v1.1
 """
 

--- a/Batt_Board/lib/battery_functions.py
+++ b/Batt_Board/lib/battery_functions.py
@@ -1,6 +1,6 @@
 """
-This is the class that contains all of the functions for our CubeSat. 
-We pass the cubesat object to it for the definitions and then it executes 
+This is the class that contains all of the functions for our CubeSat.
+We pass the cubesat object to it for the definitions and then it executes
 our will.
 Authors: Nicole Maggard and Michael Pham 12/26/2023
 """

--- a/Batt_Board/main.py
+++ b/Batt_Board/main.py
@@ -20,11 +20,11 @@ def debug_print(statement):
 
     # Defining Operations Within The Power Modes
     """These functions is called when the satellite transitions between various power states.
-    It generally thse modes manage the battery, checks the state of health of the system, 
-    performs a reboot check, and then puts the system into a short hibernation 
+    It generally thse modes manage the battery, checks the state of health of the system,
+    performs a reboot check, and then puts the system into a short hibernation
     mode to conserve power.
 
-    When in low or critical power modes, the satellite will not perform any complex tasks. 
+    When in low or critical power modes, the satellite will not perform any complex tasks.
 
     The sub-functions that can be called are:
     - `battery_manager()`: Manages and monitors the battery status.

--- a/FC_Board/lib/functions.py
+++ b/FC_Board/lib/functions.py
@@ -1,6 +1,6 @@
 """
-This is the class that contains all of the functions for our CubeSat. 
-We pass the cubesat object to it for the definitions and then it executes 
+This is the class that contains all of the functions for our CubeSat.
+We pass the cubesat object to it for the definitions and then it executes
 our will.
 Authors: Nicole Maggard, Michael Pham, and Rachel Sarmiento
 """

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-.PHONY: fmt
-fmt:
-	black .

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # flight_controller_software
-Software for the flight controller board in the PROVES Kit. We recent updated this to reflect the impending PROVES Kit V2. In that version of the kit we have both software in Circuit Python and C++ using the PicoSDK. The file tree has been updated to reflect this. Please access either the **CircuitPy (for Circuit Python software)** or **PicoSDK (For C++ Software)** as needed! 
 
-Also check out the [development software repo](https://github.com/proveskit/development_software) for our latest experimental software! 
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![CI](https://github.com/texas-state-space-lab/pikvm-tailscale-certificate-renewer/actions/workflows/ci.yaml/badge.svg)
+
+Software for the flight controller board in the PROVES Kit. We recent updated this to reflect the impending PROVES Kit V2. In that version of the kit we have both software in Circuit Python and C++ using the PicoSDK. The file tree has been updated to reflect this. Please access either the **CircuitPy (for Circuit Python software)** or **PicoSDK (For C++ Software)** as needed!
+
+Also check out the [development software repo](https://github.com/proveskit/development_software) for our latest experimental software!
 
 # Usage
-Depending on whether you are trying to use the CircuitPython or PicoSDK software, there are some different steps you need to follow. 
+Depending on whether you are trying to use the CircuitPython or PicoSDK software, there are some different steps you need to follow.
 
-For CircuitPython load new software by doing the following: 
+For CircuitPython load new software by doing the following:
 1. Clone the branch you wish to put on your board to your local machine.
 2. Connect to the target board so it mounts as an external drive.
 3. Access the target board using a serial terminal and run the following code in the REPL to erase all of the existing code:
@@ -26,7 +30,21 @@ __For Battery Board__
 from pysquared_eps import cubesat as c
 ```
 
-# General Structure: 
+# Development Getting Started
+We welcome contributions so please feel free to join us. If you have any questions about contributing please open an issue or a discussion.
+
+We have a few python tools to make development safer, easier, and more consistent. To get started you'll need to set up your python virtual environment (venv).
+
+1. Create your venv `python3 -m venv venv`
+2. Activate your venv `source ./venv/bin/activate`
+3. Install required packages `pip install -r requirements.txt`
+
+## Precommit hooks
+Everytime you make a change in git, it's called a commit. We have a tool called a precommit hook that will run before you make each commit to ensure your code is safe and formatted correctly. To install the precommit hook:
+
+1. Install the precommit hook with `pre-commit install`
+
+## General Structure:
 - **boot.py** This is the code that runs on boot and initializes the stack limit
 - **cdh.py** This is the code that handles all the commands. A majority of this code is pulled from the cdh file developed by Max Holliday at Stanford.
 - **code.py** This code runs the main operating system of the satellite and handles errors on a high level allowing the system to be fault tolerant
@@ -57,10 +75,3 @@ This software contains all of the libraries required to operate the sensors, pys
 - **pysquared_rfm9x.py** This is a library that implements all the radio hardware. This code is a modified version of the pycubed_rfm9x which is a modified version of the adafruit_rfm9x file.
 ## tests
 This software is used for performing tests on the satellite
-
-## Linting setup
-
-1. Create your venv `python3 -m venv venv`
-2. Activate your venv `source ./venv/bin/activate`
-3. Install required packages `pip install -r requirements.txt`
-4. Run the automatic formatter with `make fmt`

--- a/Tests/radio_test.py
+++ b/Tests/radio_test.py
@@ -34,17 +34,17 @@ cubesat.radio1.receive_timeout = radio_cfg["receive_timeout"]
 cubesat.radio1.enable_crc = False
 
 print(
-    """ 
-======================================= 
-|                                     | 
-|              WELCOME!               | 
+    """
+=======================================
+|                                     |
+|              WELCOME!               |
 |       Radio Test Version 1.0        |
 |                                     |
 =======================================
-|       Please Select Your Node       | 
+|       Please Select Your Node       |
 | 'A': Device Under Test              |
-| 'B': Receiver                       | 
-======================================= 
+| 'B': Receiver                       |
+=======================================
 """
 )
 
@@ -132,9 +132,9 @@ if device_selection not in options:
 
 else:
     print(
-        """ 
-    ======================================= 
-    |                                     | 
+        """
+    =======================================
+    |                                     |
     |       Verbose Output? (Y/N)         |
     |                                     |
     =======================================
@@ -149,10 +149,10 @@ else:
         debug_mode = False
 
 print(
-    """ 
-======================================= 
-|                                     | 
-|        Beginning Radio Test         | 
+    """
+=======================================
+|                                     |
+|        Beginning Radio Test         |
 |       Radio Test Version 1.0        |
 |                                     |
 =======================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,16 @@
 black==24.4.2
+cfgv==3.4.0
 click==8.1.7
+distlib==0.3.8
+filelock==3.15.4
+identify==2.6.0
 mypy-extensions==1.0.0
+nodeenv==1.9.1
 packaging==24.1
 pathspec==0.12.1
 platformdirs==4.2.2
+pre-commit==3.8.0
+PyYAML==6.0.1
 tomli==2.0.1
 typing_extensions==4.12.2
+virtualenv==20.26.3


### PR DESCRIPTION
Following @TheSilentDefender's suggestion, this PR implements a precommit hook which runs the previously implemented linter `black` as well as a few additional white space checks. All code changes are whitespace only and should not impact compilation or runtime behavior.

The manual file modifications in this PR are:
- `.pre-commit-config.yaml`
- `README.md`
- `requirements.txt`

This is what is looks like when the precommit hook runs:
```sh
pre-commit run --all-files
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
black....................................................................Passed
```