### PR TITLE
multiBitFlag rollover to 0 once max is reached

### DIFF
--- a/lib/pysquared/bitflags.py
+++ b/lib/pysquared/bitflags.py
@@ -43,7 +43,7 @@ class multiBitFlag:
         return (obj.micro.nvm[self.byte] & self.bit_mask) >> self.lowest_bit
 
     def __set__(self, obj, value):
-        if value >= self.maxval:
+        if value > self.maxval:
             value = 0
         value <<= self.lowest_bit
         reg = obj.micro.nvm[self.byte]

--- a/lib/pysquared/bitflags.py
+++ b/lib/pysquared/bitflags.py
@@ -44,7 +44,7 @@ class multiBitFlag:
 
     def __set__(self, obj, value):
         if value >= self.maxval:
-            value = self.maxval
+            value = 0
         value <<= self.lowest_bit
         reg = obj.micro.nvm[self.byte]
         reg &= ~self.bit_mask

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -82,7 +82,7 @@ class Satellite:
             print(co("[pysquared]" + str(statement), "green", "bold"))
 
     def error_print(self, statement: Any) -> None:
-        self.c_error_count: multiBitFlag = +1  # Limited to 255 errors
+        self.c_error_count: multiBitFlag += 1  # Limited to 255 errors
         if self.debug:
             print(co("[pysquared]" + str(statement), "red", "bold"))
 

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -82,9 +82,7 @@ class Satellite:
             print(co("[pysquared]" + str(statement), "green", "bold"))
 
     def error_print(self, statement: Any) -> None:
-        self.c_error_count: multiBitFlag = (
-            self.c_error_count + 1
-        ) & 0xFF  # Limited to 255 errors
+        self.c_error_count: multiBitFlag = +1  # Limited to 255 errors
         if self.debug:
             print(co("[pysquared]" + str(statement), "red", "bold"))
 
@@ -198,8 +196,6 @@ class Satellite:
         """
         NVM Parameter Resets
         """
-        if self.c_boot > 200:
-            self.c_boot = 0
 
         if self.f_softboot:
             self.f_softboot = False

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -82,7 +82,7 @@ class Satellite:
             print(co("[pysquared]" + str(statement), "green", "bold"))
 
     def error_print(self, statement: Any) -> None:
-        self.c_error_count: multiBitFlag += 1  # Limited to 255 errors
+        self.c_error_count += 1  # Limited to 255 errors
         if self.debug:
             print(co("[pysquared]" + str(statement), "red", "bold"))
 


### PR DESCRIPTION
Currently the `multiBitFlag` class is capable of counting from 0 to the maximum value of the number of bits requested. Once at the maximum value it would not change if incremented.

This PR changes the behavior so that the `multiBitFlag` class always rolls over to 0 after reaching its maximum. We have checked the variables assigned as the `multiBitFlag` class and believe this is not a breaking change. It's different behavior that we need to expect when reading satellite logs but no functionality should break.