### PR TITLE
Update Makefile and Readme with new development experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: download-libraries help
+all: venv download-libraries pre-commit-install help
 
 .PHONY: help
 help: ## Display this help.
@@ -7,28 +7,51 @@ help: ## Display this help.
 
 ##@ Development
 
+ACTIVATE_VENV := . venv/bin/activate;
+BOARD_MOUNT_POINT ?= /Volumes/PYSQUARED
+
+venv:
+	@echo "Creating virtual environment..."
+	@python3 -m venv venv
+	@$(ACTIVATE_VENV) pip install --upgrade pip --quiet
+	@$(ACTIVATE_VENV) pip install --requirement requirements.txt --quiet
+
+.PHONY: download-libraries
+download-libraries: venv ## Download the required libraries
+	@echo "Downloading libraries..."
+	@$(ACTIVATE_VENV) pip install --requirement lib/requirements.txt --target lib --no-deps --upgrade --quiet
+	@rm -rf lib/*.dist-info
+
+.PHONY: pre-commit-install
+pre-commit-install: venv
+	@echo "Installing pre-commit hooks..."
+	@$(ACTIVATE_VENV) pre-commit install > /dev/null
+
 .PHONY: fmt
-fmt: ## Lint and format files
-	pre-commit run --all-files
+fmt: pre-commit-install ## Lint and format files
+	$(ACTIVATE_VENV) pre-commit run --all-files
 
 .PHONY: test
-test: ## Run tests
-	python3 -m pytest tests/unit
+test: venv ## Run tests
+	$(ACTIVATE_VENV) python3 -m pytest tests/unit
+
+.PHONY: install
+install: build ## Install the project onto a connected PROVES Kit use `BOARD_MOUNT_POINT` to specify the mount point
+	rsync -avh artifacts/proves/ $(BOARD_MOUNT_POINT) --delete
+
+.PHONY: clean
+clean: ## Remove all gitignored files such as downloaded libraries and artifacts
+	git clean -dfX
 
 ##@ Build
 
 .PHONY: build
 build: download-libraries ## Build the project, store the result in the artifacts directory
-	rm -rf artifacts/proves/
-	mkdir -p artifacts/proves
-	cp config.json artifacts/proves/
-	cp ./*.py artifacts/proves/
-	find ./lib -type d -name '__pycache__' -prune -o -type f -print | cpio -pdm artifacts/proves/
-	zip -r artifacts/proves.zip artifacts/proves
-
-##@ Library Management
-
-download-libraries: ## Download the required libraries
-	@echo "Downloading libraries..."
-	@pip3 install --requirement lib/requirements.txt --target lib --no-deps --upgrade --quiet
-	@rm -rf lib/*.dist-info
+	@echo "Creating artifacts/proves"
+	@rm -rf artifacts/proves/
+	@mkdir -p artifacts/proves
+	@cp config.json artifacts/proves/
+	@cp ./*.py artifacts/proves/
+	@find ./lib -type d -name '__pycache__' -prune -o -type f -print | cpio -pdm artifacts/proves/
+	@echo "Creating artifacts/proves.zip"
+	@zip -r artifacts/proves.zip artifacts/proves > /dev/null

--- a/README.md
+++ b/README.md
@@ -35,23 +35,44 @@ from pysquared_eps import cubesat as c
 # Development Getting Started
 We welcome contributions so please feel free to join us. If you have any questions about contributing please open an issue or a discussion.
 
-We have a few python tools to make development safer, easier, and more consistent. To get started you'll need to set up your python virtual environment (venv).
+We have a few python tools to make development safer, easier, and more consistent. To get started you'll need to run
+```sh
+make
+```
 
-1. Create your venv `python3 -m venv venv`
-2. Activate your venv `source ./venv/bin/activate`
-3. Install required packages `pip install -r requirements.txt`
-4. Download necessary libraries `make download-libraries`
+## Manually testing code on the board
+We are working on improving our automated testing but right now the best way to test your code is to run it on the board. We have provided the following command to make it easy to install code on the board:
+```sh
+make install BOARD_MOUNT_POINT=/PATH_TO_YOUR_BOARD
+```
 
-## Precommit hooks
-Everytime you make a change in git, it's called a commit. We have a tool called a precommit hook that will run before you make each commit to ensure your code is safe and formatted correctly.
+You can find the path to your board by looking for the volume named `PYSQUARED`
 
-To install the precommit hook:
+### Mac
+```sh
+ls -lah /Volumes
+...
+drwx------@  1 nate  staff    16K Jan  9 08:09 PYSQUARED/
+```
 
-1. Install the precommit hook with `pre-commit install`
+### Linux or Windows via WSL
+```sh
+df -h
+```
 
-To run the precommit hook:
+## Build failures
 
-1. Run the precommit hook against all files with `make fmt`
+### Lint failure
+Everytime you make a change in git, it's called a commit. We have a tool called a precommit hook that will run before you make each commit to ensure your code is safe and formatted correctly. If you experience a lint failure you can run the following to fix it for you or tell you what's wrong.
+```sh
+make fmt
+```
+
+### Test failure
+To ensure our code works we use automated testing. If you're seeing a testing failure in your build, you can see what's wrong by running those tests yourself with:
+```
+make test
+```
 
 ## General Structure:
 - **boot.py** This is the code that runs on boot and initializes the stack limit


### PR DESCRIPTION
## Summary

This PR updates the `Makefile` with new targets to help developers.

Running `make` takes the place of all of our setup instructions. It will setup the venv, download all dependencies, install the pre-commit hook.

You can also deploy to the board just by running `make install`

`make help` displays more of what you can do!

```sh
make help

Usage:
  make <target>
  help             Display this help.

Development
  download-libraries  Download the required libraries
  fmt              Lint and format files
  test             Run tests
  install          Install the project onto a connected PROVES Kit use `BOARD_MOUNT_POINT` to specify the mount point
  clean           Remove all gitignored files such as downloaded libraries and artifacts

Build
  build            Build the project, store the result in the artifacts directory
```

## Testing
No testing required, this is a local/pipeline only change.

FYI @Mikefly123 we were talking about something like this for devs in a previous PR.