### PR TITLE
Bit Flag & Boot Count Refactor & Pytesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This software contains all of the libraries required to operate the sensors, pys
 - **adafruit_veml7700.py** This is the library that is responsible for obtaining data from the veml7700 Light Sensor
 - **adafruit_vl6180.py** This is the library that is responsible for obtaining data from the vl6180 LiDAR sensor
 - **Big_Data.py** This is a class developed to obtain data from the sensors on the 5 solar faces. Since all the faces maintain all the same sensors, this class handles the individual face sensors and returns them all to the main code.
-- **bitflags.py** This is code that allows for some registers within the microcontroller to be written to and saved through power cycles
+- **flag.py** This is code that allows for some registers within the microcontroller to be written to and saved through power cycles
 - **debugcolor.py** This is code that allows for easier debugging and is used by individual classes. Each class utilizes a different color and makes debugging substantially easier
 - **Field.py** This is code that implements the radio module for sending and listening
 - **functions.py** This is a library of functions utilized by the satellite to obtain data, detumble, run the battery heater

--- a/lib/pysquared/cdh.py
+++ b/lib/pysquared/cdh.py
@@ -115,7 +115,7 @@ def hreset(cubesat):
 
 
 def FSK(cubesat):
-    cubesat.f_fsk = True
+    cubesat.f_fsk.toggle(True)
 
 
 def joke_reply(cubesat):
@@ -132,7 +132,7 @@ def shutdown(cubesat, args):
     if args == b"\x0b\xfdI\xec":
         print("valid shutdown command received")
         # set shutdown NVM bit flag
-        cubesat.f_shtdwn = True
+        cubesat.f_shtdwn.toggle(True)
 
         """
         Exercise for the user:
@@ -154,7 +154,7 @@ def shutdown(cubesat, args):
             monotonic_time=time.monotonic() + eval("1e" + str(_t))
         )  # default 1 day
         # set hot start flag right before sleeping
-        cubesat.f_hotstrt = True
+        cubesat.f_hotstrt.toggle(True)
         alarm.exit_and_deep_sleep_until_alarms(time_alarm)
 
 

--- a/lib/pysquared/functions.py
+++ b/lib/pysquared/functions.py
@@ -198,9 +198,9 @@ class functions:
                 f"AT:{self.cubesat.internal_temperature}",
                 f"BT:{self.last_battery_temp}",
                 f"EC:{self.cubesat.error_count.get()}",
-                f"AB:{int(self.cubesat.burned)}",
-                f"BO:{int(self.cubesat.f_brownout)}",
-                f"FK:{int(self.cubesat.f_fsk)}",
+                f"AB:{int(self.cubesat.f_burned.get())}",
+                f"BO:{int(self.cubesat.f_brownout.get())}",
+                f"FK:{int(self.cubesat.f_fsk.get())}",
             ]
         except Exception as e:
             self.debug_print(

--- a/lib/pysquared/functions.py
+++ b/lib/pysquared/functions.py
@@ -443,7 +443,7 @@ class functions:
         # all should be off from cubesat powermode
 
         self.cubesat.enable_rf.value = False
-        self.cubesat.f_softboot = True
+        self.cubesat.f_softboot.toggle(True)
         self.safe_sleep(120)
 
         self.cubesat.enable_rf.value = True
@@ -455,7 +455,7 @@ class functions:
         # all should be off from cubesat powermode
 
         self.cubesat.enable_rf.value = False
-        self.cubesat.f_softboot = True
+        self.cubesat.f_softboot.toggle(True)
         self.safe_sleep(600)
 
         self.cubesat.enable_rf.value = True

--- a/lib/pysquared/nvm/bitflags.py
+++ b/lib/pysquared/nvm/bitflags.py
@@ -1,21 +1,29 @@
+try:
+    from stubs.circuitpython.byte_array import ByteArray
+except ImportError:
+    pass
+
+
 class bitFlag:
     """
-    Single bit register WITHIN a byte that can be read or set
-    values are 'bool'
-
-    Assumes register is read MSB!
-
+    get() -> bool: Check if specific bit in a specific byte (held in byte array of nvm) is on (1 -> True) or off (0 -> False)
+    toggle(value: bool) -> None: Set specific bit in a specific byte (held in byte array of nvm) to on (1) or off (0)
     """
 
-    def __init__(self, register, bit):
-        self.bit_mask = 1 << (bit % 8)  # the bitmask *within* the byte!
-        self.byte = register
+    def __init__(self, index: int, bit: int, datastore: ByteArray) -> None:
+        self._index = index  # Index of specific byte in array of bytes
+        self._bit = bit  # Position of bit within specific byte
+        self._datastore = datastore  # Array of bytes (Non-volatile Memory)
+        self._bit_mask = 1 << (bit % 8)  # Creating bitmask with bit position
+        # Ex. bit = 3 -> 3 % 8 = 3 -> 1 << 3 = 00001000
 
-    def __get__(self, obj, objtype=None):
-        return bool(obj.micro.nvm[self.byte] & self.bit_mask)
+    def get(self) -> bool:  # Return if bit value/flag is on (1) or off (0)
+        return bool(self._datastore[self._index] & self._bit_mask)
 
-    def __set__(self, obj, value):
+    def toggle(self, value: bool) -> None:
         if value:
-            obj.micro.nvm[self.byte] |= self.bit_mask
+            # If true, perform OR on specific byte and bitmask to set bit to set specific bit to 1
+            self._datastore[self._index] |= self._bit_mask
         else:
-            obj.micro.nvm[self.byte] &= ~self.bit_mask
+            # If false, perform AND on specific byte and inverted bitmask to set specific bit to 0
+            self._datastore[self._index] &= ~self._bit_mask

--- a/lib/pysquared/nvm/flag.py
+++ b/lib/pysquared/nvm/flag.py
@@ -4,23 +4,24 @@ except ImportError:
     pass
 
 
-class bitFlag:
+class Flag:
     """
-    get() -> bool: Check if specific bit in a specific byte (held in byte array of nvm) is on (1 -> True) or off (0 -> False)
-    toggle(value: bool) -> None: Set specific bit in a specific byte (held in byte array of nvm) to on (1) or off (0)
+    Flag class for managing boolean flags stored in non-volatile memory
     """
 
-    def __init__(self, index: int, bit: int, datastore: ByteArray) -> None:
+    def __init__(self, index: int, bit_index: int, datastore: ByteArray) -> None:
         self._index = index  # Index of specific byte in array of bytes
-        self._bit = bit  # Position of bit within specific byte
+        self._bit = bit_index  # Position of bit within specific byte
         self._datastore = datastore  # Array of bytes (Non-volatile Memory)
-        self._bit_mask = 1 << (bit % 8)  # Creating bitmask with bit position
+        self._bit_mask = 1 << bit_index  # Creating bitmask with bit position
         # Ex. bit = 3 -> 3 % 8 = 3 -> 1 << 3 = 00001000
 
-    def get(self) -> bool:  # Return if bit value/flag is on (1) or off (0)
+    def get(self) -> bool:
+        """Get flag value"""
         return bool(self._datastore[self._index] & self._bit_mask)
 
     def toggle(self, value: bool) -> None:
+        """Toggle flag value"""
         if value:
             # If true, perform OR on specific byte and bitmask to set bit to set specific bit to 1
             self._datastore[self._index] |= self._bit_mask

--- a/lib/pysquared/nvm/flag.py
+++ b/lib/pysquared/nvm/flag.py
@@ -23,8 +23,8 @@ class Flag:
     def toggle(self, value: bool) -> None:
         """Toggle flag value"""
         if value:
-            # If true, perform OR on specific byte and bitmask to set bit to set specific bit to 1
+            # If true, perform OR on specific byte and bitmask to set bit to 1
             self._datastore[self._index] |= self._bit_mask
         else:
-            # If false, perform AND on specific byte and inverted bitmask to set specific bit to 0
+            # If false, perform AND on specific byte and inverted bitmask to set bit to 0
             self._datastore[self._index] &= ~self._bit_mask

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -61,7 +61,6 @@ class Satellite:
 
     # Define NVM flags
     f_softboot: Flag = Flag(index=_FLAG, bit_index=0, datastore=microcontroller.nvm)
-    f_burnarm: Flag = Flag(index=_FLAG, bit_index=2, datastore=microcontroller.nvm)
     f_brownout: Flag = Flag(index=_FLAG, bit_index=3, datastore=microcontroller.nvm)
     f_shtdwn: Flag = Flag(index=_FLAG, bit_index=5, datastore=microcontroller.nvm)
     f_burned: Flag = Flag(index=_FLAG, bit_index=6, datastore=microcontroller.nvm)
@@ -185,8 +184,8 @@ class Satellite:
             ]
         )
 
-        if self.f_softboot:
-            self.f_softboot.toggle(True)
+        if self.f_softboot.get():
+            self.f_softboot.toggle(False)
 
         """
         Setting up the watchdog pin.
@@ -288,7 +287,7 @@ class Satellite:
         self.radio1_DIO4.switch_to_input()
 
         try:
-            if self.f_fsk:
+            if self.f_fsk.get():
                 self.radio1: rfm9xfsk.RFM9xFSK = rfm9xfsk.RFM9xFSK(
                     self.spi0,
                     _rf_cs1,
@@ -417,7 +416,7 @@ class Satellite:
         """
         self.scan_tca_channels()
 
-        if self.f_fsk:
+        if self.f_fsk.get():
             self.debug_print("Next restart will be in LoRa mode.")
             self.f_fsk.toggle(False)
 
@@ -516,22 +515,6 @@ class Satellite:
 
         except Exception as e:
             self.error_print(f"[ERROR][CLOCK SPEED]{traceback.format_exception(e)}")
-
-    @property
-    def burnarm(self) -> Flag:
-        return self.f_burnarm
-
-    @burnarm.setter
-    def burnarm(self, value: Flag) -> None:
-        self.f_burnarm: Flag = value
-
-    @property
-    def burned(self) -> Flag:
-        return self.f_burned
-
-    @burned.setter
-    def burned(self, value: Flag) -> None:
-        self.f_burned: Flag = value
 
     @property
     def RGB(self) -> tuple[int, int, int]:

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -31,8 +31,8 @@ import lib.pysquared.rv3028 as rv3028  # Real Time Clock
 from lib.adafruit_lsm6ds.lsm6dsox import LSM6DSOX  # IMU
 from lib.adafruit_rfm import rfm9x, rfm9xfsk  # Radio
 from lib.pysquared.debugcolor import co
-from lib.pysquared.nvm.bitflags import bitFlag
 from lib.pysquared.nvm.counter import Counter
+from lib.pysquared.nvm.flag import Flag
 
 try:
     from typing import Any, OrderedDict, TextIO, Union
@@ -60,14 +60,12 @@ class Satellite:
     error_count: Counter = Counter(index=_ERRORCNT, datastore=microcontroller.nvm)
 
     # Define NVM flags
-    f_softboot: bitFlag = bitFlag(index=_FLAG, bit=0, datastore=microcontroller.nvm)
-    f_solar: bitFlag = bitFlag(index=_FLAG, bit=1, datastore=microcontroller.nvm)
-    f_burnarm: bitFlag = bitFlag(index=_FLAG, bit=2, datastore=microcontroller.nvm)
-    f_brownout: bitFlag = bitFlag(index=_FLAG, bit=3, datastore=microcontroller.nvm)
-    f_triedburn: bitFlag = bitFlag(index=_FLAG, bit=4, datastore=microcontroller.nvm)
-    f_shtdwn: bitFlag = bitFlag(index=_FLAG, bit=5, datastore=microcontroller.nvm)
-    f_burned: bitFlag = bitFlag(index=_FLAG, bit=6, datastore=microcontroller.nvm)
-    f_fsk: bitFlag = bitFlag(index=_FLAG, bit=7, datastore=microcontroller.nvm)
+    f_softboot: Flag = Flag(index=_FLAG, bit_index=0, datastore=microcontroller.nvm)
+    f_burnarm: Flag = Flag(index=_FLAG, bit_index=2, datastore=microcontroller.nvm)
+    f_brownout: Flag = Flag(index=_FLAG, bit_index=3, datastore=microcontroller.nvm)
+    f_shtdwn: Flag = Flag(index=_FLAG, bit_index=5, datastore=microcontroller.nvm)
+    f_burned: Flag = Flag(index=_FLAG, bit_index=6, datastore=microcontroller.nvm)
+    f_fsk: Flag = Flag(index=_FLAG, bit_index=7, datastore=microcontroller.nvm)
 
     def debug_print(self, statement: Any) -> None:
         """
@@ -520,20 +518,20 @@ class Satellite:
             self.error_print(f"[ERROR][CLOCK SPEED]{traceback.format_exception(e)}")
 
     @property
-    def burnarm(self) -> bitFlag:
+    def burnarm(self) -> Flag:
         return self.f_burnarm
 
     @burnarm.setter
-    def burnarm(self, value: bitFlag) -> None:
-        self.f_burnarm: bitFlag = value
+    def burnarm(self, value: Flag) -> None:
+        self.f_burnarm: Flag = value
 
     @property
-    def burned(self) -> bitFlag:
+    def burned(self) -> Flag:
         return self.f_burned
 
     @burned.setter
-    def burned(self, value: bitFlag) -> None:
-        self.f_burned: bitFlag = value
+    def burned(self, value: Flag) -> None:
+        self.f_burned: Flag = value
 
     @property
     def RGB(self) -> tuple[int, int, int]:

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -60,14 +60,14 @@ class Satellite:
     error_count: Counter = Counter(index=_ERRORCNT, datastore=microcontroller.nvm)
 
     # Define NVM flags
-    f_softboot: bitFlag = bitFlag(register=_FLAG, bit=0)
-    f_solar: bitFlag = bitFlag(register=_FLAG, bit=1)
-    f_burnarm: bitFlag = bitFlag(register=_FLAG, bit=2)
-    f_brownout: bitFlag = bitFlag(register=_FLAG, bit=3)
-    f_triedburn: bitFlag = bitFlag(register=_FLAG, bit=4)
-    f_shtdwn: bitFlag = bitFlag(register=_FLAG, bit=5)
-    f_burned: bitFlag = bitFlag(register=_FLAG, bit=6)
-    f_fsk: bitFlag = bitFlag(register=_FLAG, bit=7)
+    f_softboot: bitFlag = bitFlag(index=_FLAG, bit=0, datastore=microcontroller.nvm)
+    f_solar: bitFlag = bitFlag(index=_FLAG, bit=1, datastore=microcontroller.nvm)
+    f_burnarm: bitFlag = bitFlag(index=_FLAG, bit=2, datastore=microcontroller.nvm)
+    f_brownout: bitFlag = bitFlag(index=_FLAG, bit=3, datastore=microcontroller.nvm)
+    f_triedburn: bitFlag = bitFlag(index=_FLAG, bit=4, datastore=microcontroller.nvm)
+    f_shtdwn: bitFlag = bitFlag(index=_FLAG, bit=5, datastore=microcontroller.nvm)
+    f_burned: bitFlag = bitFlag(index=_FLAG, bit=6, datastore=microcontroller.nvm)
+    f_fsk: bitFlag = bitFlag(index=_FLAG, bit=7, datastore=microcontroller.nvm)
 
     def debug_print(self, statement: Any) -> None:
         """

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -186,7 +186,7 @@ class Satellite:
         )
 
         if self.f_softboot:
-            self.f_softboot = False
+            self.f_softboot.toggle(True)
 
         """
         Setting up the watchdog pin.
@@ -419,7 +419,7 @@ class Satellite:
 
         if self.f_fsk:
             self.debug_print("Next restart will be in LoRa mode.")
-            self.f_fsk = False
+            self.f_fsk.toggle(False)
 
         """
         Prints init State of PySquared Hardware

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/repl/radio_test.py
+++ b/tests/repl/radio_test.py
@@ -33,7 +33,7 @@ if input("FSK or LoRa? [L/f]") == "F":
     print("Resetting in FSK")
     from pysquared import cubesat
 
-print("FSK: " + str(cubesat.f_fsk))
+print("FSK: " + str(cubesat.f_fsk.get()))
 
 options = ["A", "B", "C"]
 

--- a/tests/repl/radio_test.py
+++ b/tests/repl/radio_test.py
@@ -28,7 +28,7 @@ radio_cfg = {
 }
 
 if input("FSK or LoRa? [L/f]") == "F":
-    cubesat.f_fsk = True
+    cubesat.f_fsk.toggle(True)
     del cubesat
     print("Resetting in FSK")
     from pysquared import cubesat

--- a/tests/unit/lib/pysquared/nvm/test_bitflags.py
+++ b/tests/unit/lib/pysquared/nvm/test_bitflags.py
@@ -1,0 +1,57 @@
+import pytest
+
+import lib.pysquared.nvm.bitflags as bitflags
+from mocks.circuitpython.byte_array import ByteArray
+
+
+@pytest.fixture
+def setup_datastore():
+    return ByteArray(size=17)
+
+
+def test_init(setup_datastore):
+    flag = bitflags.bitFlag(16, 0, setup_datastore)  # Example flag for softboot
+    assert flag._index == 16  # Check if _index (index of byte array) is set to 16
+    assert flag._bit == 0  # Check if _bit (bit position) is set to first index of byte
+    assert flag._bit_mask == 0b00000001  # Check if _bit_mask is set correctly
+
+
+def test_get(setup_datastore):
+    flag = bitflags.bitFlag(16, 1, setup_datastore)  # Example flag for solar
+    assert setup_datastore[16] == 0b00000000
+    assert flag.get().equals(False)  # Bit should be 0 by default
+
+    setup_datastore[16] = 0b00000010  # Manually set bit to test
+    assert flag.get().equals(True)  # Should return true since bit position 1 = 1
+
+
+def test_toggle(setup_datastore):
+    flag = bitflags.bitFlag(16, 2, setup_datastore)  # Example flag for burnarm
+    assert setup_datastore[16] == 0b00000000
+    flag.toggle(False)  # Set flag to off (bit to 0)
+    assert setup_datastore[16] == 0b00000000
+    assert flag.get().equals(False)  # Bit should remain 0 due to 0 by default
+
+    flag.toggle(True)  # Set flag to on (bit to 1)
+    assert setup_datastore[16] == 0b00000100  # Check if bit position 2 = 1
+    assert flag.get().equals(True)  # Bit should be flipped to 1
+
+    flag.toggle(True)  # Set flag to on (bit to 1)
+    assert setup_datastore[16] == 0b00000100  # Check if bit position 2 = 1
+    assert flag.get().equals(True)  # Bit should remain 1 due to already being set to on
+
+    flag.toggle(False)  # Set flag back to off (bit to 0)
+    assert setup_datastore[16] == 0b00000000  # Check if bit position 2 = 0
+    assert flag.get().equals(False)  # Bit should be 0
+
+
+def test_edge_cases(setup_datastore):
+    first_bit = bitflags.bitFlag(0, 0, setup_datastore)
+    first_bit.toggle(True)
+    assert setup_datastore[0] == 0b00000001
+    assert first_bit.get().equals(True)
+
+    last_bit = bitflags.bitFlag(0, 7, setup_datastore)
+    last_bit.toggle(True)
+    assert setup_datastore[0] == 0b10000001
+    assert last_bit.get().equals(True)

--- a/tests/unit/lib/pysquared/nvm/test_bitflags.py
+++ b/tests/unit/lib/pysquared/nvm/test_bitflags.py
@@ -19,10 +19,10 @@ def test_init(setup_datastore):
 def test_get(setup_datastore):
     flag = bitflags.bitFlag(16, 1, setup_datastore)  # Example flag for solar
     assert setup_datastore[16] == 0b00000000
-    assert flag.get().equals(False)  # Bit should be 0 by default
+    assert not flag.get()  # Bit should be 0 by default
 
     setup_datastore[16] = 0b00000010  # Manually set bit to test
-    assert flag.get().equals(True)  # Should return true since bit position 1 = 1
+    assert flag.get()  # Should return true since bit position 1 = 1
 
 
 def test_toggle(setup_datastore):
@@ -30,28 +30,28 @@ def test_toggle(setup_datastore):
     assert setup_datastore[16] == 0b00000000
     flag.toggle(False)  # Set flag to off (bit to 0)
     assert setup_datastore[16] == 0b00000000
-    assert flag.get().equals(False)  # Bit should remain 0 due to 0 by default
+    assert not flag.get()  # Bit should remain 0 due to 0 by default
 
     flag.toggle(True)  # Set flag to on (bit to 1)
     assert setup_datastore[16] == 0b00000100  # Check if bit position 2 = 1
-    assert flag.get().equals(True)  # Bit should be flipped to 1
+    assert flag.get()  # Bit should be flipped to 1
 
     flag.toggle(True)  # Set flag to on (bit to 1)
     assert setup_datastore[16] == 0b00000100  # Check if bit position 2 = 1
-    assert flag.get().equals(True)  # Bit should remain 1 due to already being set to on
+    assert flag.get()  # Bit should remain 1 due to already being set to on
 
     flag.toggle(False)  # Set flag back to off (bit to 0)
     assert setup_datastore[16] == 0b00000000  # Check if bit position 2 = 0
-    assert flag.get().equals(False)  # Bit should be 0
+    assert not flag.get()  # Bit should be 0
 
 
 def test_edge_cases(setup_datastore):
     first_bit = bitflags.bitFlag(0, 0, setup_datastore)
     first_bit.toggle(True)
     assert setup_datastore[0] == 0b00000001
-    assert first_bit.get().equals(True)
+    assert first_bit.get()
 
     last_bit = bitflags.bitFlag(0, 7, setup_datastore)
     last_bit.toggle(True)
     assert setup_datastore[0] == 0b10000001
-    assert last_bit.get().equals(True)
+    assert last_bit.get()

--- a/tests/unit/lib/pysquared/nvm/test_flag.py
+++ b/tests/unit/lib/pysquared/nvm/test_flag.py
@@ -1,6 +1,6 @@
 import pytest
 
-import lib.pysquared.nvm.bitflags as bitflags
+from lib.pysquared.nvm.flag import Flag
 from mocks.circuitpython.byte_array import ByteArray
 
 
@@ -10,14 +10,14 @@ def setup_datastore():
 
 
 def test_init(setup_datastore):
-    flag = bitflags.bitFlag(16, 0, setup_datastore)  # Example flag for softboot
+    flag = Flag(16, 0, setup_datastore)  # Example flag for softboot
     assert flag._index == 16  # Check if _index (index of byte array) is set to 16
     assert flag._bit == 0  # Check if _bit (bit position) is set to first index of byte
     assert flag._bit_mask == 0b00000001  # Check if _bit_mask is set correctly
 
 
 def test_get(setup_datastore):
-    flag = bitflags.bitFlag(16, 1, setup_datastore)  # Example flag for solar
+    flag = Flag(16, 1, setup_datastore)  # Example flag for solar
     assert setup_datastore[16] == 0b00000000
     assert not flag.get()  # Bit should be 0 by default
 
@@ -26,7 +26,7 @@ def test_get(setup_datastore):
 
 
 def test_toggle(setup_datastore):
-    flag = bitflags.bitFlag(16, 2, setup_datastore)  # Example flag for burnarm
+    flag = Flag(16, 2, setup_datastore)  # Example flag for burnarm
     assert setup_datastore[16] == 0b00000000
     flag.toggle(False)  # Set flag to off (bit to 0)
     assert setup_datastore[16] == 0b00000000
@@ -46,12 +46,12 @@ def test_toggle(setup_datastore):
 
 
 def test_edge_cases(setup_datastore):
-    first_bit = bitflags.bitFlag(0, 0, setup_datastore)
+    first_bit = Flag(0, 0, setup_datastore)
     first_bit.toggle(True)
     assert setup_datastore[0] == 0b00000001
     assert first_bit.get()
 
-    last_bit = bitflags.bitFlag(0, 7, setup_datastore)
+    last_bit = Flag(0, 7, setup_datastore)
     last_bit.toggle(True)
     assert setup_datastore[0] == 0b10000001
     assert last_bit.get()


### PR DESCRIPTION
Removed unused bitflag.py code (nateinaction) and simplified functoriality:
- get() -> bool: Check if specific bit in a specific byte (held in byte array of non-volatile memory) is on (1 -> True) or off (0 -> False)
- toggle(value: bool) -> None: Set specific bit in a specific byte (held in byte array of nvm) to on (1) or off (0)

(tests>unit>lib/pysquared>test_bitflags.py) Implemented pytests for get() and toggle() functions (checking and setting bits in bytes of nvm byte array)

(nateinaction) New boot counter class (lib>pysquared>nvm>counter.py) and pytests (tests>unit>lib/pysquared>test_counter.py):
- get() -> int: Returns value of counter in nvm
- increment() -> None: Increments counter in nvm by one (now properly rolls over after reaching above 255) 

