### PR TITLE
Enforce lf line endings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,12 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-added-large-files
+    - id: mixed-line-ending
+      args: [ --fix=lf ]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.8.6

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "files.eol": "\n",
     "python.testing.pytestArgs": [
         "tests/unit"
     ],

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+[format]
+# Use `\n` line endings for all files
+line-ending = "lf"


### PR DESCRIPTION
Doing our best to enforce `lf` line endings to prevent PRs with lots of accidental line changes. Thoughts @dbgen1?