### PR TITLE
fix the RTC time/date setters/getters

### DIFF
--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -617,15 +617,12 @@ class Satellite:
         except Exception as e:
             self.error_print("[ERROR][mag]" + "".join(traceback.format_exception(e)))
 
-    @property
-    def time(self) -> Union[tuple[int, int, int], None]:
-        try:
-            return self.rtc.get_time()
-        except Exception as e:
-            self.error_print("[ERROR][RTC]" + "".join(traceback.format_exception(e)))
-
     @time.setter
-    def time(self, hours: int, minutes: int, seconds: int) -> None:
+    def time(self, hms: tuple[int, int, int]) -> None:
+        """
+        hms: A 3-tuple of ints containing data for the hours, minutes, and seconds respectively.
+        """
+        hours, minutes, seconds = hms
         if self.hardware["RTC"]:
             try:
                 self.rtc.set_time(hours, minutes, seconds)
@@ -644,7 +641,11 @@ class Satellite:
             self.error_print("[ERROR][RTC]" + "".join(traceback.format_exception(e)))
 
     @date.setter
-    def date(self, year: int, month: int, date: int, weekday: int) -> None:
+    def date(self, ymdw: tuple[int, int, int, int]) -> None:
+        """
+        ymdw: A 4-tuple of ints containing data for the year, month, date, and weekday respectively.
+        """
+        year, month, date, weekday = ymdw
         if self.hardware["RTC"]:
             try:
                 self.rtc.set_date(year, month, date, weekday)


### PR DESCRIPTION
This fixes the real time clock getters and setters in `pysquared.py` by making the properties correctly take only one argument, and adds docstrings for clarity. Related to #40 