### PR TITLE
Update config.json to Default is_licensed as False

### DIFF
--- a/config.json
+++ b/config.json
@@ -48,7 +48,7 @@
 "legacy": false,
 "heating": false,
 "orpheus":true,
-"is_licensed":true,
+"is_licensed":False,
 "NORMAL_TEMP": 20,
 "NORMAL_BATT_TEMP": 1,
 "NORMAL_MICRO_TEMP": 20,


### PR DESCRIPTION
Changed default for `is_licensed` from `True` to `False`

This blocks the radio from transmitting automatically when `main.py` is run. This avoids possible damage to the radio if there is no antenna attached and mitigates the risk that an illegal transmission is made if no licensed amateur radio operator is present.