### PR TITLE
Expand Windows Makefile Compatability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,26 @@ help: ## Display this help.
 
 ifeq ($(OS),Windows_NT)
 BIN_DIR := venv/Scripts
-PYTHON := $(BIN_DIR)/python.exe
+PYTHON := $(shell which python)
+VENV_PYTHON := $(BIN_DIR)/python.exe
 else
 BIN_DIR := venv/bin
-PYTHON := $(BIN_DIR)/python
+PYTHON := python3
+VENV_PYTHON := $(BIN_DIR)/python
 endif
 
 ACTIVATE_VENV := . $(BIN_DIR)/activate;
 
 venv:
 	@echo "Creating virtual environment..."
-	@python3 -m venv venv
-	@$(ACTIVATE_VENV) pip install --upgrade pip --quiet
-	@$(ACTIVATE_VENV) pip install --requirement requirements.txt --quiet
+	@$(PYTHON) -m venv venv
+	@$(VENV_PYTHON) -m pip install --upgrade pip --quiet
+	@$(VENV_PYTHON) -m pip install --requirement requirements.txt --quiet
 
 .PHONY: download-libraries
 download-libraries: venv ## Download the required libraries
 	@echo "Downloading libraries..."
-	@$(ACTIVATE_VENV) pip install --requirement lib/requirements.txt --target lib --no-deps --upgrade --quiet
+	@$(VENV_PYTHON) -m pip install --requirement lib/requirements.txt --target lib --no-deps --upgrade --quiet
 	@rm -rf lib/*.dist-info
 
 .PHONY: pre-commit-install


### PR DESCRIPTION
# What is Changed
Hey team! I'm on this fork on the main repo to try and work on some updates specifically for the InspireFly Version of the PROVES Kit that the Virginia Tech folks are flying. I noticed when I tried to do the `make` process on my windows machine that I kept running into permission errors. 

I think the permission errors were due to the fact that I had *both* a Windows Store download of Python and a direct install of Python on my machine at the same time. When I uninstalled the Windows Store Python, I would instead get a `Python was not found` error like the attached screenshot: 

![image](https://github.com/user-attachments/assets/681d061b-5515-45b2-9f60-3427170e54b6)

I verified that Python was on the path and all that, but it seemed like the `Makefile` was expecting to find Python in the Windows Store install location even though it was no longer there. I make some changes to the `Makefile` to essentially check which Python is currently on the path and then use that for setting up the `venv` and it seems to work like a charm now! 

It would be great to get some extra feedback on how this works on other people's windows machines. I don't have a bunch of experience with `make`, so if this change breaks functionalities in an unexpected way please let me know! 