### PR TITLE
Delete .github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,6 +1,0 @@
-Please switch to **Preview** and select one of the following links:
-
-* [Feature](?template=feature.md)
-* [Bug](?template=bug.md)
-
-Once switched to the correct template, you can save the link as a bookmark. Keep in mind that switching templates will remove all already entered data within this issue.


### PR DESCRIPTION
This issue template isn't needed as GitHub automatically shows a list of the templates.