### PR TITLE
removing unused parameters in 3 functions

### DIFF
--- a/lib/pysquared/cdh.py
+++ b/lib/pysquared/cdh.py
@@ -175,6 +175,6 @@ class CommandDataHandler:
 
         cubesat.radio1.send(data=str(eval(args)))
 
-    def exec_cmd(self, args) -> None:
+    def exec_cmd(self, cubesat: Satellite, args) -> None:
         self.logger.info("Executing command", args=args)
         exec(args)

--- a/lib/pysquared/cdh.py
+++ b/lib/pysquared/cdh.py
@@ -175,6 +175,6 @@ class CommandDataHandler:
 
         cubesat.radio1.send(data=str(eval(args)))
 
-    def exec_cmd(self, cubesat: Satellite, args) -> None:
+    def exec_cmd(self, args) -> None:
         self.logger.info("Executing command", args=args)
         exec(args)

--- a/lib/pysquared/functions.py
+++ b/lib/pysquared/functions.py
@@ -349,7 +349,7 @@ class functions:
 
     # Goal for torque is to make a control system
     # that will adjust position towards Earth based on Gyro data
-    def detumble(self, dur: int = 7, margin: float = 0.2, seq: int = 118) -> None:
+    def detumble(self, dur: int = 7) -> None:
         self.logger.debug("Detumbling")
         self.cubesat.RGB = (255, 255, 255)
 

--- a/lib/pysquared/packet_sender.py
+++ b/lib/pysquared/packet_sender.py
@@ -89,7 +89,7 @@ class PacketSender:
         )
         return True
 
-    def handle_retransmit_request(self, packets, request_packet, logger: Logger):
+    def handle_retransmit_request(self, packets, request_packet):
         """Handle retransmit request by sending requested packets"""
         import time
 
@@ -115,9 +115,7 @@ class PacketSender:
             self.logger.error("Error handling retransmit request", err=e)
             return False
 
-    def fast_send_data(
-        self, data, logger: Logger, send_delay=0.5, retransmit_wait=15.0
-    ):
+    def fast_send_data(self, data, send_delay=0.5, retransmit_wait=15.0):
         """Send data with improved retransmission handling"""
         import time
 


### PR DESCRIPTION
I removed an unused parameter in 3 functions

2 functions had a Logger object as a parameter. At some point in time for the initial Logger implementation, I hadn't yet used dependency injection for the packet_sender class, so I passed a parameter of a Logger to 2 functions.

I just realized I had forgotten to delete the logger parameters. Being that there is a self.logger member, that is now used in the packet_sender class. My apologies for the mistake

I also realized that the exec_cmd function has a Satellite parameter that isn't used