### PR TITLE
fixed small typo in pysquared.py

### DIFF
--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -160,7 +160,7 @@ class Satellite:
             )
             self.radio1.max_output = True
             self.radio1.tx_power = self.radio_cfg["transmit_power"]
-            self.radio1.spreading_factor = self.radio_cfg["LoRa_spread_factor"]
+            self.radio1.spreading_factor = self.radio_cfg["LoRa_spreading_factor"]
 
             self.radio1.enable_crc = True
             self.radio1.ack_delay = 0.2


### PR DESCRIPTION
## Summary
Typo in pysquared.py. Tested on board and not logging an error anymore.

## How was this tested
- [ ] Added new unit tests
- [X] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
