### PR TITLE
Improve install speed from ~200s to ~80s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: venv download-libraries pre-commit-install help
+all: .venv download-libraries pre-commit-install help
 
 .PHONY: help
 help: ## Display this help.

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ define rsync_to_dest
 		echo "Issue with Make target, rsync destination is not specified. Stopping."; \
 		exit 1; \
 	fi
-	@rsync -avh config.json ./*.py ./lib --exclude='requirements.txt' --exclude='__pycache__' $(1) --delete
+	@rsync -avh config.json ./*.py ./lib --exclude='requirements.txt' --exclude='__pycache__' $(1) --delete --times --checksum
 endef
 
 ##@ Build Tools


### PR DESCRIPTION
## Summary
This PR only impacts Mac and Linux users.

This PR changes the technique that rsync uses to understand if there have been changes to the files. When we run `make install` it should only sync the modified files. Unfortunately due to some circumstances related to the board being treated as an external drive and circuitpython implementing its own filesystem, the traditional way that rsync works doesn't. This changes rsync to use a "slower" syncing method using file checksums but it turns out being much faster for our purposes.


## How was this tested
- [x] Ran code on hardware

Before change:
```sh
time make install -o download-libraries BOARD_MOUNT_POINT="/Volumes/PYSQUARED\  /"
...
Executed in  208.62 secs      fish           external
```

After change:
```sh
time make install -o download-libraries BOARD_MOUNT_POINT="/Volumes/PYSQUARED\  /"
...
Executed in   83.96 secs      fish           external
```
