### PR TITLE
Introduce radio factory

### DIFF
--- a/lib/pysquared/Field.py
+++ b/lib/pysquared/Field.py
@@ -4,13 +4,15 @@ This class handles communications
 Authors: Nicole Maggard, Michael Pham, and Rachel Sarmiento
 """
 
+from lib.adafruit_rfm.rfm_common import RFMSPI
 from lib.pysquared.logger import Logger
 
 
 class Field:
-    def __init__(self, cubesat, logger: Logger):
+    def __init__(self, cubesat, logger: Logger, radio: RFMSPI):
         self.cubesat = cubesat
         self.logger = logger
+        self.radio = radio
 
     def Beacon(self, msg):
         if not self.cubesat.is_licensed:
@@ -20,7 +22,7 @@ class Field:
             return
 
         try:
-            sent = self.cubesat.radio1.send(bytes(msg, "UTF-8"))
+            sent = self.radio.send(bytes(msg, "UTF-8"))
         except Exception as e:
             self.logger.error("There was an error while Beaconing", err=e)
             return

--- a/lib/pysquared/decorators.py
+++ b/lib/pysquared/decorators.py
@@ -3,7 +3,7 @@ import time
 from lib.pysquared.exception import HardwareInitializationError
 
 
-def with_retries(max_attempts: int = 3, initial_delay: int = 1):
+def with_retries(max_attempts: int = 3, initial_delay: float = 1.0):
     """Decorator that retries hardware initialization with exponential backoff.
 
     :param int max_attempts: Maximum number of attempts to try initialization (default is 3)

--- a/lib/pysquared/decorators.py
+++ b/lib/pysquared/decorators.py
@@ -1,5 +1,4 @@
 import time
-from functools import wraps
 
 from lib.pysquared.exception import HardwareInitializationError
 
@@ -16,7 +15,6 @@ def with_retries(max_attempts: int = 3, initial_delay: int = 1):
     """
 
     def decorator(func):
-        @wraps(func)
         def wrapper(*args, **kwargs):
             last_exception = None
             delay = initial_delay

--- a/lib/pysquared/decorators.py
+++ b/lib/pysquared/decorators.py
@@ -1,0 +1,38 @@
+import time
+from functools import wraps
+
+from lib.pysquared.exception import HardwareInitializationError
+
+
+def with_retries(max_attempts: int = 3, initial_delay: int = 1):
+    """Decorator that retries hardware initialization with exponential backoff.
+
+    :param int max_attempts: Maximum number of attempts to try initialization (default is 3)
+    :param int initial_delay: Initial delay in seconds between attempts (default is 1.0)
+
+    :raises HardwareInitializationError: If all attempts fail, the last exception is raised
+
+    :returns: The result of the decorated function if successful
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            last_exception = None
+            delay = initial_delay
+
+            for attempt in range(max_attempts):
+                try:
+                    return func(*args, **kwargs)
+                except HardwareInitializationError as e:
+                    last_exception = e
+                    if attempt < max_attempts - 1:  # Don't sleep on last attempt
+                        time.sleep(delay)
+                        delay *= 2  # Exponential backoff
+
+            # If we get here, all attempts failed
+            raise last_exception
+
+        return wrapper
+
+    return decorator

--- a/lib/pysquared/exception.py
+++ b/lib/pysquared/exception.py
@@ -1,0 +1,9 @@
+class HardwareInitializationError(Exception):
+    def __init__(self, name, exception=None):
+        self._name = name
+        self._exception = exception
+
+    def __str__(self):
+        if self._exception:
+            return f"Failed to initialize: {self._name} - Exception: {self._exception}"
+        return self.message

--- a/lib/pysquared/hardware.py
+++ b/lib/pysquared/hardware.py
@@ -1,0 +1,37 @@
+from digitalio import DigitalInOut, Direction
+from microcontroller import Pin
+
+from lib.pysquared.decorators import with_retries
+from lib.pysquared.exception import HardwareInitializationError
+from lib.pysquared.logger import Logger
+
+
+@with_retries(max_attempts=3, initial_delay=1)
+def initialize_pin(
+    logger: Logger, pin: Pin, direction: Direction, initial_value: bool
+) -> DigitalInOut:
+    """Initializes a DigitalInOut pin.
+
+    :param Logger logger: The logger instance to log messages.
+    :param Pin pin: The pin to initialize.
+    :param Direction direction: The direction of the pin.
+    :param bool initial_value: The initial value of the pin (default is True).
+
+    :raises HardwareInitializationError: If the pin fails to initialize.
+
+    :return ~digitalio.DigitalInOut: The initialized DigitalInOut object.
+    """
+    logger.debug(
+        message="Initializing pin",
+        pin=pin,
+        direction=direction,
+        initial_value=initial_value,
+    )
+
+    try:
+        digital_in_out = DigitalInOut(pin)
+        digital_in_out.direction = direction
+        digital_in_out.value = initial_value
+        return digital_in_out
+    except Exception as e:
+        raise HardwareInitializationError(f"Failed to initialize pin {pin}") from e

--- a/lib/pysquared/rfm9x_factory.py
+++ b/lib/pysquared/rfm9x_factory.py
@@ -1,6 +1,5 @@
 from busio import SPI
 from digitalio import DigitalInOut
-from microcontroller import Pin
 
 from lib.adafruit_rfm.rfm9x import RFM9x
 from lib.adafruit_rfm.rfm9xfsk import RFM9xFSK
@@ -27,8 +26,8 @@ class RFM9xFactory:
         cls,
         logger: Logger,
         spi: SPI,
-        chip_select: Pin,
-        reset: Pin,
+        chip_select: DigitalInOut,
+        reset: DigitalInOut,
         use_fsk: Flag,
         sender_id: int,
         receiver_id: int,
@@ -56,24 +55,18 @@ class RFM9xFactory:
         logger.debug(message="Initializing radio", mode=cls.radio_mode(use_fsk))
 
         try:
-            cs: DigitalInOut = DigitalInOut(chip_select)
-            cs.switch_to_output(value=True)
-
-            rst: DigitalInOut = DigitalInOut(reset)
-            rst.switch_to_output(value=True)
-
             if use_fsk.get():
                 radio: RFMSPI = cls.create_fsk_radio(
                     spi,
-                    cs,
-                    rst,
+                    chip_select,
+                    reset,
                     frequency,
                 )
             else:
                 radio: RFMSPI = cls.create_lora_radio(
                     spi,
-                    cs,
-                    rst,
+                    chip_select,
+                    reset,
                     frequency,
                     transmit_power,
                     lora_spreading_factor,
@@ -88,7 +81,7 @@ class RFM9xFactory:
                 "Failed to initialize radio", mode=cls.radio_mode(use_fsk), err=e
             )
 
-            raise HardwareInitializationError("radio", e)
+            raise HardwareInitializationError("radio", e) from e
 
     @staticmethod
     def radio_mode(use_fsk: Flag) -> str:

--- a/lib/pysquared/rfm9x_factory.py
+++ b/lib/pysquared/rfm9x_factory.py
@@ -1,0 +1,166 @@
+from busio import SPI
+from digitalio import DigitalInOut
+from machine import Pin
+
+from lib.adafruit_rfm.rfm9x import RFM9x
+from lib.adafruit_rfm.rfm9xfsk import RFM9xFSK
+from lib.adafruit_rfm.rfm_common import RFMSPI
+from lib.pysquared.exception import HardwareInitializationError
+from lib.pysquared.logger import Logger
+from lib.pysquared.nvm.flag import Flag
+
+
+class RFM9xMode:
+    """Enumeration for the RFM9x radio mode."""
+
+    FSK = "fsk"
+    LORA = "lora"
+
+
+class RFM9xFactory:
+    """Factory class for creating RFM9x radio instances."""
+
+    @classmethod
+    def create(
+        cls,
+        logger: Logger,
+        spi: SPI,
+        chip_select: Pin,
+        reset: Pin,
+        use_fsk: Flag,
+        sender_id: int,
+        receiver_id: int,
+        frequency: int,
+        transmit_power: int,
+        lora_spreading_factor: int,
+    ) -> RFMSPI:
+        """Create a RFM9x radio instance.
+
+        :param Logger logger: Logger instance for logging messages.
+        :param busio.SPI spi: The SPI bus connected to the chip. Ensure SCK, MOSI, and MISO are connected.
+        :param ~digitalio.DigitalInOut cs: A DigitalInOut object connected to the chip's CS/chip select line.
+        :param ~digitalio.DigitalInOut reset: A DigitalInOut object connected to the chip's RST/reset line.
+        :param Flag use_fsk: Flag to determine whether to use FSK or LoRa mode.
+        :param int sender_id: ID of the sender radio.
+        :param int receiver_id: ID of the receiver radio.
+        :param int frequency: Frequency at which the radio will transmit.
+        :param int transmit_power: Transmit power level (applicable for LoRa only).
+        :param int lora_spreading_factor: Spreading factor for LoRa modulation (applicable for LoRa only).
+
+        :raises HardwareInitializationError: If the radio fails to initialize.
+
+        :return An instance of the RFMSPI class, either RFM9xFSK or RFM9x based on the mode.
+        """
+        try:
+            logger.debug(message="Initializing radio", mode=cls.radio_mode(use_fsk))
+
+            cs: DigitalInOut = DigitalInOut(chip_select)
+            cs.switch_to_output(value=True)
+
+            rst: DigitalInOut = DigitalInOut(reset)
+            rst.switch_to_output(value=True)
+
+            if use_fsk.get():
+                radio: RFMSPI = cls.create_fsk_radio(
+                    spi,
+                    cs,
+                    rst,
+                    frequency,
+                )
+            else:
+                radio: RFMSPI = cls.create_lora_radio(
+                    spi,
+                    cs,
+                    rst,
+                    frequency,
+                    transmit_power,
+                    lora_spreading_factor,
+                )
+
+            radio.node = sender_id
+            radio.destination = receiver_id
+
+            return radio
+        except Exception as e:
+            logger.critical(
+                "Failed to initialize radio", mode=cls.radio_mode(use_fsk), err=e
+            )
+
+            raise HardwareInitializationError("radio", e)
+
+    @staticmethod
+    def radio_mode(use_fsk: Flag) -> str:
+        """Get the radio mode based on the flag.
+
+        :param Flag use_fsk: Flag to determine whether to use FSK or LoRa mode.
+
+        :return The radio mode.
+        """
+        return RFM9xMode.FSK if use_fsk.get() else RFM9xMode.LORA
+
+    @staticmethod
+    def create_fsk_radio(
+        spi: SPI,
+        cs: DigitalInOut,
+        rst: DigitalInOut,
+        frequency: int,
+    ) -> RFMSPI:
+        """Create a FSK radio instance.
+
+        :param busio.SPI spi: The SPI bus connected to the chip. Ensure SCK, MOSI, and MISO are connected.
+        :param ~digitalio.DigitalInOut cs: A DigitalInOut object connected to the chip's CS/chip select line.
+        :param ~digitalio.DigitalInOut reset: A DigitalInOut object connected to the chip's RST/reset line.
+        :param int frequency: Frequency at which the radio will transmit.
+
+        :return An instance of :class:`~adafruit_rfm.rfm9xfsk.RFM9xFSK`.
+        """
+        radio: RFM9xFSK = RFM9xFSK(
+            spi,
+            cs,
+            rst,
+            frequency,
+        )
+
+        radio.fsk_broadcast_address = 255
+        radio.fsk_node_address = 1
+        radio.modulation_type
+
+        return radio
+
+    @staticmethod
+    def create_lora_radio(
+        spi: SPI,
+        cs: DigitalInOut,
+        rst: DigitalInOut,
+        frequency: int,
+        transmit_power: int,
+        lora_spreading_factor: int,
+    ) -> RFMSPI:
+        """Create a LoRa radio instance.
+
+        :param busio.SPI spi: The SPI bus connected to the chip. Ensure SCK, MOSI, and MISO are connected.
+        :param ~digitalio.DigitalInOut cs: A DigitalInOut object connected to the chip's CS/chip select line.
+        :param ~digitalio.DigitalInOut reset: A DigitalInOut object connected to the chip's RST/reset line.
+        :param int frequency: Frequency at which the radio will transmit.
+        :param int transmit_power: Transmit power level (applicable for LoRa only).
+        :param int lora_spreading_factor: Spreading factor for LoRa modulation (applicable for LoRa only).
+
+        :return An instance of the RFM9x class.
+        """
+        radio: RFM9x = RFM9x(
+            spi,
+            cs,
+            rst,
+            frequency,
+        )
+
+        radio.ack_delay = 0.2
+        radio.enable_crc = True
+        radio.max_output = True
+        radio.spreading_factor = lora_spreading_factor
+        radio.tx_power = transmit_power
+
+        if radio.spreading_factor > 9:
+            radio.preamble_length = radio.spreading_factor
+
+        return radio

--- a/lib/pysquared/rfm9x_factory.py
+++ b/lib/pysquared/rfm9x_factory.py
@@ -5,6 +5,7 @@ from machine import Pin
 from lib.adafruit_rfm.rfm9x import RFM9x
 from lib.adafruit_rfm.rfm9xfsk import RFM9xFSK
 from lib.adafruit_rfm.rfm_common import RFMSPI
+from lib.pysquared.decorators import with_retries
 from lib.pysquared.exception import HardwareInitializationError
 from lib.pysquared.logger import Logger
 from lib.pysquared.nvm.flag import Flag
@@ -21,6 +22,7 @@ class RFM9xFactory:
     """Factory class for creating RFM9x radio instances."""
 
     @classmethod
+    @with_retries(max_attempts=3, initial_delay=1)
     def create(
         cls,
         logger: Logger,

--- a/lib/pysquared/rfm9x_factory.py
+++ b/lib/pysquared/rfm9x_factory.py
@@ -1,6 +1,6 @@
 from busio import SPI
 from digitalio import DigitalInOut
-from machine import Pin
+from microcontroller import Pin
 
 from lib.adafruit_rfm.rfm9x import RFM9x
 from lib.adafruit_rfm.rfm9xfsk import RFM9xFSK
@@ -53,9 +53,9 @@ class RFM9xFactory:
 
         :return An instance of the RFMSPI class, either RFM9xFSK or RFM9x based on the mode.
         """
-        try:
-            logger.debug(message="Initializing radio", mode=cls.radio_mode(use_fsk))
+        logger.debug(message="Initializing radio", mode=cls.radio_mode(use_fsk))
 
+        try:
             cs: DigitalInOut = DigitalInOut(chip_select)
             cs.switch_to_output(value=True)
 

--- a/main.py
+++ b/main.py
@@ -52,10 +52,10 @@ try:
         config.get_dict("radio_cfg")["receiver_id"],
         config.get_dict("radio_cfg")["transmit_frequency"],
         config.get_dict("radio_cfg")["transmit_power"],
-        config.get_dict("radio_cfg")["lora_spreading_factor"],
+        config.get_dict("radio_cfg")["LoRa_spreading_factor"],
     )
 
-    f = functions.functions(logger, config, c, radio)
+    f = functions.functions(c, logger, config, radio)
 
     def initial_boot():
         c.watchdog_pet()

--- a/main.py
+++ b/main.py
@@ -10,8 +10,10 @@ Published: Nov 19, 2024
 
 import gc
 import time
+import traceback
 
 import board
+import digitalio
 import microcontroller
 
 import lib.pysquared.functions as functions
@@ -19,6 +21,7 @@ import lib.pysquared.nvm.register as register
 import lib.pysquared.pysquared as pysquared
 from lib.adafruit_rfm.rfm_common import RFMSPI
 from lib.pysquared.config import Config
+from lib.pysquared.hardware import initialize_pin
 from lib.pysquared.logger import Logger
 from lib.pysquared.nvm.counter import Counter
 from lib.pysquared.rfm9x_factory import RFM9xFactory
@@ -45,8 +48,8 @@ try:
     radio: RFMSPI = RFM9xFactory.create(
         logger,
         c.spi0,
-        board.SPI0_CS0,
-        board.RF1_RST,
+        initialize_pin(logger, board.SPI0_CS0, digitalio.Direction.OUTPUT, True),
+        initialize_pin(logger, board.RF1_RST, digitalio.Direction.OUTPUT, True),
         c.f_fsk,
         config.get_dict("radio_cfg")["sender_id"],
         config.get_dict("radio_cfg")["receiver_id"],
@@ -77,9 +80,6 @@ try:
 
     except Exception as e:
         logger.error("Error in Boot Sequence", err=e)
-
-    finally:
-        pass
 
     def send_imu_data():
         logger.info("Looking to get imu data...")
@@ -162,4 +162,6 @@ try:
         c.hardware["WDT"] = False
 
 except Exception as e:
-    logger.error("An exception occured within main.py", err=e)
+    logger.critical(
+        "An exception occured within main.py", err=traceback.format_exception(e)
+    )


### PR DESCRIPTION
## Summary
Will fill out more words...

This PR:
- Extracts radio instantiation from the Satellite class.
- ...


## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)


### Failure modes
#### Pin cannot be initialized
If a pin required for the radio to operate cannot be initialized it will retry 2 more times then an exception will raise up to `main.py` and will cause the code to stop executing. Output looks like:
```
{"time": "2020-01-01 00:04:38", "level": "DEBUG", "direction": digitalio.Direction.OUTPUT, "pin": board.SPI0_CS0, "msg": "Initializing pin", "initial_value": true}
{"time": "2020-01-01 00:04:39", "level": "DEBUG", "direction": digitalio.Direction.OUTPUT, "pin": board.SPI0_CS0, "msg": "Initializing pin", "initial_value": true}
{"time": "2020-01-01 00:04:41", "level": "DEBUG", "direction": digitalio.Direction.OUTPUT, "pin": board.SPI0_CS0, "msg": "Initializing pin", "initial_value": true}
{"err": ["Traceback (most recent call last):\r\n  File \"lib/pysquared/hardware.py\", line 25, in initialize_pin\r\nValueError: SPI0_CS0 in use\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\r\n  File \"main.py\", line 51, in <module>\r\n  File \"lib/pysquared/decorators.py\", line 32, in wrapper\r\n  File \"lib/pysquared/decorators.py\", line 24, in wrapper\r\n  File \"lib/pysquared/hardware.py\", line 30, in initialize_pin\r\nHardwareInitializationError: Failed to initialize pin board.SPI0_CS0\n"], "msg": "An exception occured within main.py", "time": "2020-01-01 00:04:41", "level": "CRITICAL"}
```

#### Radio cannot be initialized
If the radio cannot be initialized it will retry 2 more times then an exception will raise up to `main.py` and will cause the code to stop executing. Output looks like:
```
{"msg": "Initializing radio", "time": "2020-01-01 00:11:07", "mode": "lora", "level": "DEBUG"}
{"time": "2020-01-01 00:11:07", "level": "CRITICAL", "err": ["Test"], "mode": "lora", "msg": "Failed to initialize radio"}
{"msg": "Initializing radio", "time": "2020-01-01 00:11:08", "mode": "lora", "level": "DEBUG"}
{"time": "2020-01-01 00:11:08", "level": "CRITICAL", "err": ["Test"], "mode": "lora", "msg": "Failed to initialize radio"}
{"msg": "Initializing radio", "time": "2020-01-01 00:11:10", "mode": "lora", "level": "DEBUG"}
{"time": "2020-01-01 00:11:10", "level": "CRITICAL", "err": ["Test"], "mode": "lora", "msg": "Failed to initialize radio"}
{"err": ["Traceback (most recent call last):\r\n  File \"lib/pysquared/rfm9x_factory.py\", line 58, in create\r\nValueError: Test\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\r\n  File \"main.py\", line 58, in <module>\r\n  File \"lib/pysquared/decorators.py\", line 32, in wrapper\r\n  File \"lib/pysquared/decorators.py\", line 24, in wrapper\r\n  File \"lib/pysquared/rfm9x_factory.py\", line 85, in create\r\nHardwareInitializationError: ('radio', ValueError('Test',))\n"], "msg": "An exception occured within main.py", "time": "2020-01-01 00:11:10", "level": "CRITICAL"}
```