### PR TITLE
Reformat the "err" value in json output

### DIFF
--- a/lib/pysquared/Big_Data.py
+++ b/lib/pysquared/Big_Data.py
@@ -1,4 +1,5 @@
 import gc
+import traceback
 
 import lib.adafruit_tca9548a as adafruit_tca9548a  # I2C Multiplexer
 from lib.pysquared.logger import Logger
@@ -51,7 +52,10 @@ class Face:
                 )
                 self.sensors["MCP"] = True
             except Exception as e:
-                self.logger.error("Error Initializing Temperature Sensor", err=e)
+                self.logger.error(
+                    "Error Initializing Temperature Sensor",
+                    err=traceback.format_exception(e),
+                )
 
         if "VEML" in senlist:
             try:
@@ -62,7 +66,9 @@ class Face:
                 )
                 self.sensors["VEML"] = True
             except Exception as e:
-                self.logger.error("Error Initializing Light Sensor", err=e)
+                self.logger.error(
+                    "Error Initializing Light Sensor", err=traceback.format_exception(e)
+                )
 
         if "DRV" in senlist:
             try:
@@ -73,7 +79,9 @@ class Face:
                 )
                 self.sensors["DRV"] = True
             except Exception as e:
-                self.logger.error("Error Initializing Motor Driver", err=e)
+                self.logger.error(
+                    "Error Initializing Motor Driver", err=traceback.format_exception(e)
+                )
 
         gc.collect()  # Clean up after initialization
 

--- a/lib/pysquared/Big_Data.py
+++ b/lib/pysquared/Big_Data.py
@@ -1,5 +1,4 @@
 import gc
-import traceback
 
 import lib.adafruit_tca9548a as adafruit_tca9548a  # I2C Multiplexer
 from lib.pysquared.logger import Logger
@@ -52,10 +51,7 @@ class Face:
                 )
                 self.sensors["MCP"] = True
             except Exception as e:
-                self.logger.error(
-                    "Error Initializing Temperature Sensor",
-                    err=traceback.format_exception(e),
-                )
+                self.logger.error("Error Initializing Temperature Sensor", err=e)
 
         if "VEML" in senlist:
             try:
@@ -66,9 +62,7 @@ class Face:
                 )
                 self.sensors["VEML"] = True
             except Exception as e:
-                self.logger.error(
-                    "Error Initializing Light Sensor", err=traceback.format_exception(e)
-                )
+                self.logger.error("Error Initializing Light Sensor", err=e)
 
         if "DRV" in senlist:
             try:
@@ -79,9 +73,7 @@ class Face:
                 )
                 self.sensors["DRV"] = True
             except Exception as e:
-                self.logger.error(
-                    "Error Initializing Motor Driver", err=traceback.format_exception(e)
-                )
+                self.logger.error("Error Initializing Motor Driver", err=e)
 
         gc.collect()  # Clean up after initialization
 

--- a/lib/pysquared/Big_Data.py
+++ b/lib/pysquared/Big_Data.py
@@ -51,7 +51,7 @@ class Face:
                 )
                 self.sensors["MCP"] = True
             except Exception as e:
-                self.logger.error("Error Initializing Temperature Sensor", err=e)
+                self.logger.error("Error Initializing Temperature Sensor", e)
 
         if "VEML" in senlist:
             try:
@@ -62,7 +62,7 @@ class Face:
                 )
                 self.sensors["VEML"] = True
             except Exception as e:
-                self.logger.error("Error Initializing Light Sensor", err=e)
+                self.logger.error("Error Initializing Light Sensor", e)
 
         if "DRV" in senlist:
             try:
@@ -73,7 +73,7 @@ class Face:
                 )
                 self.sensors["DRV"] = True
             except Exception as e:
-                self.logger.error("Error Initializing Motor Driver", err=e)
+                self.logger.error("Error Initializing Motor Driver", e)
 
         gc.collect()  # Clean up after initialization
 

--- a/lib/pysquared/Field.py
+++ b/lib/pysquared/Field.py
@@ -4,8 +4,6 @@ This class handles communications
 Authors: Nicole Maggard, Michael Pham, and Rachel Sarmiento
 """
 
-import traceback
-
 from lib.pysquared.logger import Logger
 from lib.pysquared.pysquared import Satellite
 
@@ -31,9 +29,7 @@ class Field:
         try:
             sent = self.cubesat.radio1.send(bytes(msg, "UTF-8"))
         except Exception as e:
-            self.logger.error(
-                "There was an error while Beaconing", err=traceback.format_exception(e)
-            )
+            self.logger.error("There was an error while Beaconing", err=e)
             return
 
         self.logger.info("I am beaconing", beacon=str(msg), success=str(sent))

--- a/lib/pysquared/Field.py
+++ b/lib/pysquared/Field.py
@@ -29,7 +29,7 @@ class Field:
         try:
             sent = self.cubesat.radio1.send(bytes(msg, "UTF-8"))
         except Exception as e:
-            self.logger.error("There was an error while Beaconing", err=e)
+            self.logger.error("There was an error while Beaconing", e)
             return
 
         self.logger.info("I am beaconing", beacon=str(msg), success=str(sent))

--- a/lib/pysquared/Field.py
+++ b/lib/pysquared/Field.py
@@ -4,6 +4,8 @@ This class handles communications
 Authors: Nicole Maggard, Michael Pham, and Rachel Sarmiento
 """
 
+import traceback
+
 from lib.pysquared.logger import Logger
 from lib.pysquared.pysquared import Satellite
 
@@ -29,7 +31,9 @@ class Field:
         try:
             sent = self.cubesat.radio1.send(bytes(msg, "UTF-8"))
         except Exception as e:
-            self.logger.error("There was an error while Beaconing", err=e)
+            self.logger.error(
+                "There was an error while Beaconing", err=traceback.format_exception(e)
+            )
             return
 
         self.logger.info("I am beaconing", beacon=str(msg), success=str(sent))

--- a/lib/pysquared/battery_helper.py
+++ b/lib/pysquared/battery_helper.py
@@ -1,5 +1,4 @@
 import time
-import traceback
 
 from lib.pysquared.logger import Logger
 
@@ -90,9 +89,7 @@ class BatteryHelper:
                 if start_idx < end_idx:
                     return text[start_idx + 1 : end_idx]
         except Exception as e:
-            self.logger.error(
-                "Error decoding message", err=traceback.format_exception(e)
-            )
+            self.logger.error("Error decoding message", err=e)
 
         return ""
 
@@ -111,7 +108,7 @@ class BatteryHelper:
             return self._read_message()
 
         except Exception as e:
-            self.logger.error("UART error", err=traceback.format_exception(e))
+            self.logger.error("UART error", err=e)
             return ""
 
     def _is_valid_message(self, msg):
@@ -156,9 +153,7 @@ class BatteryHelper:
                     )
 
             except Exception as e:
-                self.logger.error(
-                    "Error parsing metrics", err=traceback.format_exception(e)
-                )
+                self.logger.error("Error parsing metrics", err=e)
 
         self.logger.warning("Failed to get valid power metrics")
         return (0.0, 0.0, 0.0, 0.0, False, 0.0)
@@ -275,7 +270,7 @@ class BatteryHelper:
                 values = [float(x) for x in parts[:4]]
                 values.append(bool(int(parts[4])))
             except Exception as e:
-                self.logger.error("Parse error", err=traceback.format_exception(e))
+                self.logger.error("Parse error", err=e)
         parse_time = (time.monotonic() - parse_start) * 1000
 
         # Total time

--- a/lib/pysquared/battery_helper.py
+++ b/lib/pysquared/battery_helper.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 
 from lib.pysquared.logger import Logger
 
@@ -89,7 +90,9 @@ class BatteryHelper:
                 if start_idx < end_idx:
                     return text[start_idx + 1 : end_idx]
         except Exception as e:
-            self.logger.error("Error decoding message", err=e)
+            self.logger.error(
+                "Error decoding message", err=traceback.format_exception(e)
+            )
 
         return ""
 
@@ -108,7 +111,7 @@ class BatteryHelper:
             return self._read_message()
 
         except Exception as e:
-            self.logger.error("UART error", err=e)
+            self.logger.error("UART error", err=traceback.format_exception(e))
             return ""
 
     def _is_valid_message(self, msg):
@@ -153,7 +156,9 @@ class BatteryHelper:
                     )
 
             except Exception as e:
-                self.logger.error("Error parsing metrics", err=e)
+                self.logger.error(
+                    "Error parsing metrics", err=traceback.format_exception(e)
+                )
 
         self.logger.warning("Failed to get valid power metrics")
         return (0.0, 0.0, 0.0, 0.0, False, 0.0)
@@ -270,7 +275,7 @@ class BatteryHelper:
                 values = [float(x) for x in parts[:4]]
                 values.append(bool(int(parts[4])))
             except Exception as e:
-                self.logger.error("Parse error", err=e)
+                self.logger.error("Parse error", err=traceback.format_exception(e))
         parse_time = (time.monotonic() - parse_start) * 1000
 
         # Total time

--- a/lib/pysquared/battery_helper.py
+++ b/lib/pysquared/battery_helper.py
@@ -89,7 +89,7 @@ class BatteryHelper:
                 if start_idx < end_idx:
                     return text[start_idx + 1 : end_idx]
         except Exception as e:
-            self.logger.error("Error decoding message", err=e)
+            self.logger.error("Error decoding message", e)
 
         return ""
 
@@ -108,7 +108,7 @@ class BatteryHelper:
             return self._read_message()
 
         except Exception as e:
-            self.logger.error("UART error", err=e)
+            self.logger.error("UART error", e)
             return ""
 
     def _is_valid_message(self, msg):
@@ -153,7 +153,7 @@ class BatteryHelper:
                     )
 
             except Exception as e:
-                self.logger.error("Error parsing metrics", err=e)
+                self.logger.error("Error parsing metrics", e)
 
         self.logger.warning("Failed to get valid power metrics")
         return (0.0, 0.0, 0.0, 0.0, False, 0.0)
@@ -270,7 +270,7 @@ class BatteryHelper:
                 values = [float(x) for x in parts[:4]]
                 values.append(bool(int(parts[4])))
             except Exception as e:
-                self.logger.error("Parse error", err=e)
+                self.logger.error("Parse error", e)
         parse_time = (time.monotonic() - parse_start) * 1000
 
         # Total time

--- a/lib/pysquared/cdh.py
+++ b/lib/pysquared/cdh.py
@@ -1,6 +1,5 @@
 import random
 import time
-import traceback
 
 from lib.pysquared.config import Config
 from lib.pysquared.logger import Logger
@@ -77,8 +76,7 @@ class CommandDataHandler:
                     )
                 except Exception as e:
                     self.logger.error(
-                        "There was an error decoding the arguments",
-                        err=traceback.format_exception(e),
+                        "There was an error decoding the arguments", err=e
                     )
             if cmd in self._commands:
                 try:
@@ -96,9 +94,7 @@ class CommandDataHandler:
                         )
                     eval(self._commands[cmd])(cubesat, cmd_args)
                 except Exception as e:
-                    self.logger.error(
-                        "something went wrong!", err=traceback.format_exception(e)
-                    )
+                    self.logger.error("something went wrong!", err=e)
                     cubesat.radio1.send(str(e).encode())
             else:
                 self.logger.info("invalid command!")
@@ -122,10 +118,7 @@ class CommandDataHandler:
             try:
                 cubesat.radio1.send(msg[6:])
             except Exception as e:
-                self.logger.error(
-                    "There was an error repeating the message!",
-                    err=traceback.format_exception(e),
-                )
+                self.logger.error("There was an error repeating the message!", err=e)
         else:
             self.logger.info("bad code?")
 

--- a/lib/pysquared/cdh.py
+++ b/lib/pysquared/cdh.py
@@ -75,9 +75,7 @@ class CommandDataHandler:
                         "Here are the command arguments", cmd_args=cmd_args
                     )
                 except Exception as e:
-                    self.logger.error(
-                        "There was an error decoding the arguments", err=e
-                    )
+                    self.logger.error("There was an error decoding the arguments", e)
             if cmd in self._commands:
                 try:
                     if cmd_args is None:
@@ -94,7 +92,7 @@ class CommandDataHandler:
                         )
                     eval(self._commands[cmd])(cubesat, cmd_args)
                 except Exception as e:
-                    self.logger.error("something went wrong!", err=e)
+                    self.logger.error("something went wrong!", e)
                     cubesat.radio1.send(str(e).encode())
             else:
                 self.logger.info("invalid command!")
@@ -118,7 +116,7 @@ class CommandDataHandler:
             try:
                 cubesat.radio1.send(msg[6:])
             except Exception as e:
-                self.logger.error("There was an error repeating the message!", err=e)
+                self.logger.error("There was an error repeating the message!", e)
         else:
             self.logger.info("bad code?")
 

--- a/lib/pysquared/cdh.py
+++ b/lib/pysquared/cdh.py
@@ -1,5 +1,6 @@
 import random
 import time
+import traceback
 
 from lib.pysquared.config import Config
 from lib.pysquared.logger import Logger
@@ -76,7 +77,8 @@ class CommandDataHandler:
                     )
                 except Exception as e:
                     self.logger.error(
-                        "There was an error decoding the arguments", err=e
+                        "There was an error decoding the arguments",
+                        err=traceback.format_exception(e),
                     )
             if cmd in self._commands:
                 try:
@@ -94,7 +96,9 @@ class CommandDataHandler:
                         )
                     eval(self._commands[cmd])(cubesat, cmd_args)
                 except Exception as e:
-                    self.logger.error("something went wrong!", err=e)
+                    self.logger.error(
+                        "something went wrong!", err=traceback.format_exception(e)
+                    )
                     cubesat.radio1.send(str(e).encode())
             else:
                 self.logger.info("invalid command!")
@@ -118,7 +122,10 @@ class CommandDataHandler:
             try:
                 cubesat.radio1.send(msg[6:])
             except Exception as e:
-                self.logger.error("There was an error repeating the message!", err=e)
+                self.logger.error(
+                    "There was an error repeating the message!",
+                    err=traceback.format_exception(e),
+                )
         else:
             self.logger.info("bad code?")
 

--- a/lib/pysquared/functions.py
+++ b/lib/pysquared/functions.py
@@ -8,6 +8,7 @@ Authors: Nicole Maggard, Michael Pham, and Rachel Sarmiento
 import gc
 import random
 import time
+import traceback
 
 from lib.pysquared.battery_helper import BatteryHelper
 from lib.pysquared.config import Config
@@ -121,7 +122,9 @@ class functions:
                 + f"IHBPFJASTMNE! {self.callsign}"
             )
         except Exception as e:
-            self.logger.error("Error with obtaining power data: ", err=e)
+            self.logger.error(
+                "Error with obtaining power data: ", err=traceback.format_exception(e)
+            )
 
             lora_beacon: str = (
                 f"{self.callsign} Hello I am Yearling^2! I am in: "
@@ -186,7 +189,10 @@ class functions:
                 f"FK:{int(self.cubesat.f_fsk.get())}",
             ]
         except Exception as e:
-            self.logger.error("Couldn't aquire data for the state of health: ", err=e)
+            self.logger.error(
+                "Couldn't aquire data for the state of health: ",
+                err=traceback.format_exception(e),
+            )
 
         self.field: Field.Field = Field.Field(self.cubesat, self.logger)
         if not self.state_of_health_part1:
@@ -235,7 +241,10 @@ class functions:
                 keep_listening=True
             )
         except Exception as e:
-            self.logger.error("An Error has occured while listening: ", err=e)
+            self.logger.error(
+                "An Error has occured while listening: ",
+                err=traceback.format_exception(e),
+            )
             received = None
 
         try:
@@ -244,7 +253,10 @@ class functions:
                 cdh.message_handler(self.cubesat, received)
                 return True
         except Exception as e:
-            self.logger.error("An Error has occured while handling a command: ", err=e)
+            self.logger.error(
+                "An Error has occured while handling a command: ",
+                err=traceback.format_exception(e),
+            )
         finally:
             del cdh
 
@@ -258,7 +270,10 @@ class functions:
             return received is not None and "HAHAHAHAHA!" in received
 
         except Exception as e:
-            self.logger.error("An Error has occured while listening for a joke", err=e)
+            self.logger.error(
+                "An Error has occured while listening for a joke",
+                err=traceback.format_exception(e),
+            )
             return False
 
     """
@@ -296,7 +311,7 @@ class functions:
             gc.collect()
 
         except Exception as e:
-            self.logger.error("Big_Data error", err=e)
+            self.logger.error("Big_Data error", err=traceback.format_exception(e))
 
         return self.facestring
 
@@ -307,7 +322,9 @@ class functions:
             return self.battery.get_power_metrics()
 
         except Exception as e:
-            self.logger.error("Error retrieving battery data", err=e)
+            self.logger.error(
+                "Error retrieving battery data", err=traceback.format_exception(e)
+            )
             return None
 
     def get_imu_data(
@@ -327,7 +344,9 @@ class functions:
             data.append(self.cubesat.gyro)
             data.append(self.cubesat.mag)
         except Exception as e:
-            self.logger.error("Error retrieving IMU data", err=e)
+            self.logger.error(
+                "Error retrieving IMU data", err=traceback.format_exception(e)
+            )
 
         return data
 
@@ -351,12 +370,17 @@ class functions:
 
             a: Big_Data.AllFaces = Big_Data.AllFaces(self.cubesat.tca, self.logger)
         except Exception as e:
-            self.logger.error("Error Importing Big Data", err=e)
+            self.logger.error(
+                "Error Importing Big Data", err=traceback.format_exception(e)
+            )
 
         try:
             a.sequence = 52
         except Exception as e:
-            self.logger.error("Error setting motor driver sequences", err=e)
+            self.logger.error(
+                "Error setting motor driver sequences",
+                err=traceback.format_exception(e),
+            )
 
         def actuate(dipole: list[float], duration) -> None:
             # TODO figure out if there is a way to reverse direction of sequence
@@ -387,11 +411,11 @@ class functions:
                     time.sleep(1)
                     actuate(dipole, dur)
             except Exception as e:
-                self.logger.error("Detumble error", err=e)
+                self.logger.error("Detumble error", err=traceback.format_exception(e))
 
         try:
             self.logger.debug("Attempting")
             do_detumble()
         except Exception as e:
-            self.logger.error("Detumble error", err=e)
+            self.logger.error("Detumble error", err=traceback.format_exception(e))
         self.cubesat.RGB = (100, 100, 50)

--- a/lib/pysquared/functions.py
+++ b/lib/pysquared/functions.py
@@ -121,7 +121,7 @@ class functions:
                 + f"IHBPFJASTMNE! {self.callsign}"
             )
         except Exception as e:
-            self.logger.error("Error with obtaining power data: ", err=e)
+            self.logger.error("Error with obtaining power data: ", e)
 
             lora_beacon: str = (
                 f"{self.callsign} Hello I am Yearling^2! I am in: "
@@ -186,7 +186,7 @@ class functions:
                 f"FK:{int(self.cubesat.f_fsk.get())}",
             ]
         except Exception as e:
-            self.logger.error("Couldn't aquire data for the state of health: ", err=e)
+            self.logger.error("Couldn't aquire data for the state of health: ", e)
 
         self.field: Field.Field = Field.Field(self.cubesat, self.logger)
         if not self.state_of_health_part1:
@@ -235,7 +235,7 @@ class functions:
                 keep_listening=True
             )
         except Exception as e:
-            self.logger.error("An Error has occured while listening: ", err=e)
+            self.logger.error("An Error has occured while listening: ", e)
             received = None
 
         try:
@@ -244,7 +244,7 @@ class functions:
                 cdh.message_handler(self.cubesat, received)
                 return True
         except Exception as e:
-            self.logger.error("An Error has occured while handling a command: ", err=e)
+            self.logger.error("An Error has occured while handling a command: ", e)
         finally:
             del cdh
 
@@ -258,7 +258,7 @@ class functions:
             return received is not None and "HAHAHAHAHA!" in received
 
         except Exception as e:
-            self.logger.error("An Error has occured while listening for a joke", err=e)
+            self.logger.error("An Error has occured while listening for a joke", e)
             return False
 
     """
@@ -296,7 +296,7 @@ class functions:
             gc.collect()
 
         except Exception as e:
-            self.logger.error("Big_Data error", err=e)
+            self.logger.error("Big_Data error", e)
 
         return self.facestring
 
@@ -307,7 +307,7 @@ class functions:
             return self.battery.get_power_metrics()
 
         except Exception as e:
-            self.logger.error("Error retrieving battery data", err=e)
+            self.logger.error("Error retrieving battery data", e)
             return None
 
     def get_imu_data(
@@ -327,7 +327,7 @@ class functions:
             data.append(self.cubesat.gyro)
             data.append(self.cubesat.mag)
         except Exception as e:
-            self.logger.error("Error retrieving IMU data", err=e)
+            self.logger.error("Error retrieving IMU data", e)
 
         return data
 
@@ -351,12 +351,12 @@ class functions:
 
             a: Big_Data.AllFaces = Big_Data.AllFaces(self.cubesat.tca, self.logger)
         except Exception as e:
-            self.logger.error("Error Importing Big Data", err=e)
+            self.logger.error("Error Importing Big Data", e)
 
         try:
             a.sequence = 52
         except Exception as e:
-            self.logger.error("Error setting motor driver sequences", err=e)
+            self.logger.error("Error setting motor driver sequences", e)
 
         def actuate(dipole: list[float], duration) -> None:
             # TODO figure out if there is a way to reverse direction of sequence
@@ -387,11 +387,11 @@ class functions:
                     time.sleep(1)
                     actuate(dipole, dur)
             except Exception as e:
-                self.logger.error("Detumble error", err=e)
+                self.logger.error("Detumble error", e)
 
         try:
             self.logger.debug("Attempting")
             do_detumble()
         except Exception as e:
-            self.logger.error("Detumble error", err=e)
+            self.logger.error("Detumble error", e)
         self.cubesat.RGB = (100, 100, 50)

--- a/lib/pysquared/functions.py
+++ b/lib/pysquared/functions.py
@@ -8,7 +8,6 @@ Authors: Nicole Maggard, Michael Pham, and Rachel Sarmiento
 import gc
 import random
 import time
-import traceback
 
 from lib.pysquared.battery_helper import BatteryHelper
 from lib.pysquared.config import Config
@@ -122,9 +121,7 @@ class functions:
                 + f"IHBPFJASTMNE! {self.callsign}"
             )
         except Exception as e:
-            self.logger.error(
-                "Error with obtaining power data: ", err=traceback.format_exception(e)
-            )
+            self.logger.error("Error with obtaining power data: ", err=e)
 
             lora_beacon: str = (
                 f"{self.callsign} Hello I am Yearling^2! I am in: "
@@ -189,10 +186,7 @@ class functions:
                 f"FK:{int(self.cubesat.f_fsk.get())}",
             ]
         except Exception as e:
-            self.logger.error(
-                "Couldn't aquire data for the state of health: ",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("Couldn't aquire data for the state of health: ", err=e)
 
         self.field: Field.Field = Field.Field(self.cubesat, self.logger)
         if not self.state_of_health_part1:
@@ -241,10 +235,7 @@ class functions:
                 keep_listening=True
             )
         except Exception as e:
-            self.logger.error(
-                "An Error has occured while listening: ",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("An Error has occured while listening: ", err=e)
             received = None
 
         try:
@@ -253,10 +244,7 @@ class functions:
                 cdh.message_handler(self.cubesat, received)
                 return True
         except Exception as e:
-            self.logger.error(
-                "An Error has occured while handling a command: ",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("An Error has occured while handling a command: ", err=e)
         finally:
             del cdh
 
@@ -270,10 +258,7 @@ class functions:
             return received is not None and "HAHAHAHAHA!" in received
 
         except Exception as e:
-            self.logger.error(
-                "An Error has occured while listening for a joke",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("An Error has occured while listening for a joke", err=e)
             return False
 
     """
@@ -311,7 +296,7 @@ class functions:
             gc.collect()
 
         except Exception as e:
-            self.logger.error("Big_Data error", err=traceback.format_exception(e))
+            self.logger.error("Big_Data error", err=e)
 
         return self.facestring
 
@@ -322,9 +307,7 @@ class functions:
             return self.battery.get_power_metrics()
 
         except Exception as e:
-            self.logger.error(
-                "Error retrieving battery data", err=traceback.format_exception(e)
-            )
+            self.logger.error("Error retrieving battery data", err=e)
             return None
 
     def get_imu_data(
@@ -344,9 +327,7 @@ class functions:
             data.append(self.cubesat.gyro)
             data.append(self.cubesat.mag)
         except Exception as e:
-            self.logger.error(
-                "Error retrieving IMU data", err=traceback.format_exception(e)
-            )
+            self.logger.error("Error retrieving IMU data", err=e)
 
         return data
 
@@ -370,17 +351,12 @@ class functions:
 
             a: Big_Data.AllFaces = Big_Data.AllFaces(self.cubesat.tca, self.logger)
         except Exception as e:
-            self.logger.error(
-                "Error Importing Big Data", err=traceback.format_exception(e)
-            )
+            self.logger.error("Error Importing Big Data", err=e)
 
         try:
             a.sequence = 52
         except Exception as e:
-            self.logger.error(
-                "Error setting motor driver sequences",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("Error setting motor driver sequences", err=e)
 
         def actuate(dipole: list[float], duration) -> None:
             # TODO figure out if there is a way to reverse direction of sequence
@@ -411,11 +387,11 @@ class functions:
                     time.sleep(1)
                     actuate(dipole, dur)
             except Exception as e:
-                self.logger.error("Detumble error", err=traceback.format_exception(e))
+                self.logger.error("Detumble error", err=e)
 
         try:
             self.logger.debug("Attempting")
             do_detumble()
         except Exception as e:
-            self.logger.error("Detumble error", err=traceback.format_exception(e))
+            self.logger.error("Detumble error", err=e)
         self.cubesat.RGB = (100, 100, 50)

--- a/lib/pysquared/logger.py
+++ b/lib/pysquared/logger.py
@@ -43,7 +43,11 @@ class Logger:
         kwargs["time"] = asctime
 
         # case where someone used debug, info, or warning yet also provides an 'err' kwarg with an Exception
-        if "err" in kwargs and isinstance(kwargs["err"], Exception):
+        if (
+            "err" in kwargs
+            and level not in ("ERROR", "CRITICAL")
+            and isinstance(kwargs["err"], Exception)
+        ):
             kwargs["err"] = traceback.format_exception(kwargs["err"])
 
         json_output = json.dumps(kwargs)

--- a/lib/pysquared/logger.py
+++ b/lib/pysquared/logger.py
@@ -78,7 +78,6 @@ class Logger:
         Log a message with severity level CRITICAL.
         """
         kwargs["err"] = traceback.format_exception(err)
-        traceback.f
         self._error_counter.increment()
         self._log("CRITICAL", 5, message, **kwargs)
 

--- a/lib/pysquared/logger.py
+++ b/lib/pysquared/logger.py
@@ -5,6 +5,7 @@ Logs can be output to standard output or saved to a file (functionality to be im
 
 import json
 import time
+import traceback
 
 from lib.pysquared.nvm.counter import Counter
 
@@ -64,17 +65,21 @@ class Logger:
         """
         self._log("WARNING", 3, message, **kwargs)
 
-    def error(self, message: str, **kwargs) -> None:
+    def error(self, message: str, err: Exception, **kwargs) -> None:
         """
         Log a message with severity level ERROR.
         """
+        kwargs["err"] = traceback.format_exception(err)
         self._error_counter.increment()
         self._log("ERROR", 4, message, **kwargs)
 
-    def critical(self, message: str, **kwargs) -> None:
+    def critical(self, message: str, err: Exception, **kwargs) -> None:
         """
         Log a message with severity level CRITICAL.
         """
+        kwargs["err"] = traceback.format_exception(err)
+        traceback.f
+        self._error_counter.increment()
         self._log("CRITICAL", 5, message, **kwargs)
 
     def get_error_count(self) -> int:

--- a/lib/pysquared/logger.py
+++ b/lib/pysquared/logger.py
@@ -42,6 +42,10 @@ class Logger:
         asctime = f"{now.tm_year}-{now.tm_mon:02d}-{now.tm_mday:02d} {now.tm_hour:02d}:{now.tm_min:02d}:{now.tm_sec:02d}"
         kwargs["time"] = asctime
 
+        # case where someone used debug, info, or warning yet also provides an 'err' kwarg with an Exception
+        if "err" in kwargs and isinstance(kwargs["err"], Exception):
+            kwargs["err"] = traceback.format_exception(kwargs["err"])
+
         json_output = json.dumps(kwargs)
 
         if self._can_print_this_level(level_value):
@@ -69,11 +73,7 @@ class Logger:
         """
         Log a message with severity level ERROR.
         """
-        kwargs["err"] = {
-            "type": type(err).__name__,
-            "message": str(err),
-            "traceback": traceback.format_exception(err),
-        }
+        kwargs["err"] = traceback.format_exception(err)
         self._error_counter.increment()
         self._log("ERROR", 4, message, **kwargs)
 
@@ -81,11 +81,7 @@ class Logger:
         """
         Log a message with severity level CRITICAL.
         """
-        kwargs["err"] = {
-            "type": type(err).__name__,
-            "message": str(err),
-            "traceback": traceback.format_exception(err),
-        }
+        kwargs["err"] = traceback.format_exception(err)
         self._error_counter.increment()
         self._log("CRITICAL", 5, message, **kwargs)
 

--- a/lib/pysquared/logger.py
+++ b/lib/pysquared/logger.py
@@ -69,7 +69,11 @@ class Logger:
         """
         Log a message with severity level ERROR.
         """
-        kwargs["err"] = traceback.format_exception(err)
+        kwargs["err"] = {
+            "type": type(err).__name__,
+            "message": str(err),
+            "traceback": traceback.format_exception(err),
+        }
         self._error_counter.increment()
         self._log("ERROR", 4, message, **kwargs)
 
@@ -77,7 +81,11 @@ class Logger:
         """
         Log a message with severity level CRITICAL.
         """
-        kwargs["err"] = traceback.format_exception(err)
+        kwargs["err"] = {
+            "type": type(err).__name__,
+            "message": str(err),
+            "traceback": traceback.format_exception(err),
+        }
         self._error_counter.increment()
         self._log("CRITICAL", 5, message, **kwargs)
 

--- a/lib/pysquared/packet_sender.py
+++ b/lib/pysquared/packet_sender.py
@@ -1,5 +1,3 @@
-import traceback
-
 from lib.adafruit_rfm import rfm9x, rfm9xfsk  # Radio
 from lib.pysquared.logger import Logger
 from lib.pysquared.packet_manager import PacketManager
@@ -127,9 +125,7 @@ class PacketSender:
             return True
 
         except Exception as e:
-            self.logger.error(
-                "Error handling retransmit request", err=traceback.format_exception(e)
-            )
+            self.logger.error("Error handling retransmit request", err=e)
             return False
 
     def fast_send_data(

--- a/lib/pysquared/packet_sender.py
+++ b/lib/pysquared/packet_sender.py
@@ -125,7 +125,7 @@ class PacketSender:
             return True
 
         except Exception as e:
-            self.logger.error("Error handling retransmit request", err=e)
+            self.logger.error("Error handling retransmit request", e)
             return False
 
     def fast_send_data(

--- a/lib/pysquared/packet_sender.py
+++ b/lib/pysquared/packet_sender.py
@@ -1,3 +1,5 @@
+import traceback
+
 from lib.adafruit_rfm import rfm9x, rfm9xfsk  # Radio
 from lib.pysquared.logger import Logger
 from lib.pysquared.packet_manager import PacketManager
@@ -125,7 +127,9 @@ class PacketSender:
             return True
 
         except Exception as e:
-            self.logger.error("Error handling retransmit request", err=e)
+            self.logger.error(
+                "Error handling retransmit request", err=traceback.format_exception(e)
+            )
             return False
 
     def fast_send_data(

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -444,8 +444,10 @@ class Satellite:
         for channel in range(len(channel_to_face)):
             try:
                 self._scan_single_channel(channel, channel_to_face)
-            except OSError:
-                self.logger.error("TCA try_lock failed. TCA may be malfunctioning.")
+            except OSError as os_error:
+                self.logger.error(
+                    "TCA try_lock failed. TCA may be malfunctioning.", err=os_error
+                )
                 self.hardware["TCA"] = False
                 return
             except Exception as e:

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -82,8 +82,8 @@ class Satellite:
             except Exception as e:
                 self.logger.error(
                     "There was an error initializing this hardware component",
+                    e,
                     hardware_key=hardware_key,
-                    err=e,
                 )
             return None
 
@@ -453,8 +453,8 @@ class Satellite:
             except Exception as e:
                 self.logger.error(
                     "There was an Exception during the scan_tca_channels function call",
+                    e,
                     face=channel_to_face[channel],
-                    err=e,
                 )
 
     def _scan_single_channel(
@@ -484,8 +484,8 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an Exception during the _scan_single_channel function call",
+                e,
                 face=channel_to_face[channel],
-                err=e,
             )
         finally:
             self.tca[channel].unlock()
@@ -509,7 +509,7 @@ class Satellite:
                 machine.set_clock(62500000)  # 62.5Mhz
 
         except Exception as e:
-            self.logger.error("There was an error trying to set the clock", err=e)
+            self.logger.error("There was an error trying to set the clock", e)
 
     @property
     def RGB(self) -> tuple[int, int, int]:
@@ -527,7 +527,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error trying to set the new RGB value",
-                err=e,
+                e,
                 value=value,
             )
 
@@ -544,20 +544,20 @@ class Satellite:
                 umount("/sd")
                 time.sleep(3)
             except Exception as e:
-                self.logger.error("There was an error unmounting the SD card", err=e)
+                self.logger.error("There was an error unmounting the SD card", e)
         try:
             self.logger.debug(
                 "Resetting VBUS [IMPLEMENT NEW FUNCTION HERE]",
             )
         except Exception as e:
-            self.logger.error("There was a vbus reset error", err=e)
+            self.logger.error("There was a vbus reset error", e)
 
     @property
     def gyro(self) -> Union[tuple[float, float, float], None]:
         try:
             return self.imu.gyro
         except Exception as e:
-            self.logger.error("There was an error retrieving the gyro values", err=e)
+            self.logger.error("There was an error retrieving the gyro values", e)
 
     @property
     def accel(self) -> Union[tuple[float, float, float], None]:
@@ -565,7 +565,7 @@ class Satellite:
             return self.imu.acceleration
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the accelerometer values", err=e
+                "There was an error retrieving the accelerometer values", e
             )
 
     @property
@@ -574,7 +574,7 @@ class Satellite:
             return self.imu.temperature
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the internal temperature value", err=e
+                "There was an error retrieving the internal temperature value", e
             )
 
     @property
@@ -583,7 +583,7 @@ class Satellite:
             return self.mangetometer.magnetic
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the magnetometer sensor values", err=e
+                "There was an error retrieving the magnetometer sensor values", e
             )
 
     @property
@@ -591,7 +591,7 @@ class Satellite:
         try:
             return self.rtc.get_time()
         except Exception as e:
-            self.logger.error("There was an error retrieving the RTC time", err=e)
+            self.logger.error("There was an error retrieving the RTC time", e)
 
     @time.setter
     def time(self, hms: tuple[int, int, int]) -> None:
@@ -608,7 +608,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error setting the RTC time",
-                err=e,
+                e,
                 hms=hms,
                 hour=hms[0],
                 minutes=hms[1],
@@ -620,7 +620,7 @@ class Satellite:
         try:
             return self.rtc.get_date()
         except Exception as e:
-            self.logger.error("There was an error retrieving RTC date", err=e)
+            self.logger.error("There was an error retrieving RTC date", e)
 
     @date.setter
     def date(self, ymdw: tuple[int, int, int, int]) -> None:
@@ -637,7 +637,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error setting the RTC date",
-                err=e,
+                e,
                 ymdw=ymdw,
                 year=ymdw[0],
                 month=ymdw[1],
@@ -688,7 +688,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an Error in changing operations of powermode",
-                err=e,
+                e,
                 mode=mode,
             )
 
@@ -712,7 +712,7 @@ class Satellite:
                         self.logger.info(line.strip())
         except Exception as e:
             self.logger.error(
-                "Can't print file", filedir=filedir, err=e, binary_mode=binary
+                "Can't print file", e, filedir=filedir, binary_mode=binary
             )
 
     def read_file(
@@ -732,9 +732,7 @@ class Satellite:
                         self.logger.debug(str(line.strip()))
                     return file
         except Exception as e:
-            self.logger.error(
-                "Can't read file", filedir=filedir, err=e, binary_mode=binary
-            )
+            self.logger.error("Can't read file", e, filedir=filedir, binary_mode=binary)
 
     def new_file(self, substring: str, binary: bool = False) -> Union[str, None]:
         """
@@ -768,7 +766,7 @@ class Satellite:
                 except Exception as e:
                     self.logger.error(
                         "Error with creating new file",
-                        err=e,
+                        e,
                         filedir="/sd" + _folder,
                     )
                     return None
@@ -780,9 +778,9 @@ class Satellite:
                 except Exception as e:
                     self.logger.error(
                         "There was an error running the stat function on this file",
+                        e,
                         filedir=ff,
                         file_num=n,
-                        err=e,
                     )
                     n: int = (n + i) % 0xFFFF
                     # print('file number is',n)
@@ -797,7 +795,5 @@ class Satellite:
             chdir("/")
             return ff
         except Exception as e:
-            self.logger.error(
-                "Error creating file", filedir=ff, err=e, binary_mode=binary
-            )
+            self.logger.error("Error creating file", e, filedir=ff, binary_mode=binary)
             return None

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -10,6 +10,7 @@ Library Repo:
 # Common CircuitPython Libs
 import sys
 import time
+import traceback
 from collections import OrderedDict
 from os import chdir, mkdir, stat
 
@@ -83,7 +84,7 @@ class Satellite:
                 self.logger.error(
                     "There was an error initializing this hardware component",
                     hardware_key=hardware_key,
-                    err=e,
+                    err=traceback.format_exception(e),
                 )
             return None
 
@@ -452,7 +453,7 @@ class Satellite:
                 self.logger.error(
                     "There was an Exception during the scan_tca_channels function call",
                     face=channel_to_face[channel],
-                    err=e,
+                    err=traceback.format_exception(e),
                 )
 
     def _scan_single_channel(
@@ -483,7 +484,7 @@ class Satellite:
             self.logger.error(
                 "There was an Exception during the _scan_single_channel function call",
                 face=channel_to_face[channel],
-                err=e,
+                err=traceback.format_exception(e),
             )
         finally:
             self.tca[channel].unlock()
@@ -507,7 +508,10 @@ class Satellite:
                 machine.set_clock(62500000)  # 62.5Mhz
 
         except Exception as e:
-            self.logger.error("There was an error trying to set the clock", err=e)
+            self.logger.error(
+                "There was an error trying to set the clock",
+                err=traceback.format_exception(e),
+            )
 
     @property
     def RGB(self) -> tuple[int, int, int]:
@@ -525,7 +529,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error trying to set the new RGB value",
-                err=e,
+                err=traceback.format_exception(e),
                 value=value,
             )
 
@@ -542,20 +546,28 @@ class Satellite:
                 umount("/sd")
                 time.sleep(3)
             except Exception as e:
-                self.logger.error("There was an error unmounting the SD card", err=e)
+                self.logger.error(
+                    "There was an error unmounting the SD card",
+                    err=traceback.format_exception(e),
+                )
         try:
             self.logger.debug(
                 "Resetting VBUS [IMPLEMENT NEW FUNCTION HERE]",
             )
         except Exception as e:
-            self.logger.error("There was a vbus reset error", err=e)
+            self.logger.error(
+                "There was a vbus reset error", err=traceback.format_exception(e)
+            )
 
     @property
     def gyro(self) -> Union[tuple[float, float, float], None]:
         try:
             return self.imu.gyro
         except Exception as e:
-            self.logger.error("There was an error retrieving the gyro values", err=e)
+            self.logger.error(
+                "There was an error retrieving the gyro values",
+                err=traceback.format_exception(e),
+            )
 
     @property
     def accel(self) -> Union[tuple[float, float, float], None]:
@@ -563,7 +575,8 @@ class Satellite:
             return self.imu.acceleration
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the accelerometer values", err=e
+                "There was an error retrieving the accelerometer values",
+                err=traceback.format_exception(e),
             )
 
     @property
@@ -572,7 +585,8 @@ class Satellite:
             return self.imu.temperature
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the internal temperature value", err=e
+                "There was an error retrieving the internal temperature value",
+                err=traceback.format_exception(e),
             )
 
     @property
@@ -581,7 +595,8 @@ class Satellite:
             return self.mangetometer.magnetic
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the magnetometer sensor values", err=e
+                "There was an error retrieving the magnetometer sensor values",
+                err=traceback.format_exception(e),
             )
 
     @property
@@ -589,7 +604,10 @@ class Satellite:
         try:
             return self.rtc.get_time()
         except Exception as e:
-            self.logger.error("There was an error retrieving the RTC time", err=e)
+            self.logger.error(
+                "There was an error retrieving the RTC time",
+                err=traceback.format_exception(e),
+            )
 
     @time.setter
     def time(self, hms: tuple[int, int, int]) -> None:
@@ -606,7 +624,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error setting the RTC time",
-                err=e,
+                err=traceback.format_exception(e),
                 hms=hms,
                 hour=hms[0],
                 minutes=hms[1],
@@ -618,7 +636,10 @@ class Satellite:
         try:
             return self.rtc.get_date()
         except Exception as e:
-            self.logger.error("There was an error retrieving RTC date", err=e)
+            self.logger.error(
+                "There was an error retrieving RTC date",
+                err=traceback.format_exception(e),
+            )
 
     @date.setter
     def date(self, ymdw: tuple[int, int, int, int]) -> None:
@@ -635,7 +656,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error setting the RTC date",
-                err=e,
+                err=traceback.format_exception(e),
                 ymdw=ymdw,
                 year=ymdw[0],
                 month=ymdw[1],
@@ -686,7 +707,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an Error in changing operations of powermode",
-                err=e,
+                err=traceback.format_exception(e),
                 mode=mode,
             )
 
@@ -710,7 +731,10 @@ class Satellite:
                         self.logger.info(line.strip())
         except Exception as e:
             self.logger.error(
-                "Can't print file", filedir=filedir, err=e, binary_mode=binary
+                "Can't print file",
+                filedir=filedir,
+                err=traceback.format_exception(e),
+                binary_mode=binary,
             )
 
     def read_file(
@@ -731,7 +755,10 @@ class Satellite:
                     return file
         except Exception as e:
             self.logger.error(
-                "Can't read file", filedir=filedir, err=e, binary_mode=binary
+                "Can't read file",
+                filedir=filedir,
+                err=traceback.format_exception(e),
+                binary_mode=binary,
             )
 
     def new_file(self, substring: str, binary: bool = False) -> Union[str, None]:
@@ -766,7 +793,7 @@ class Satellite:
                 except Exception as e:
                     self.logger.error(
                         "Error with creating new file",
-                        err=e,
+                        err=traceback.format_exception(e),
                         filedir="/sd" + _folder,
                     )
                     return None
@@ -780,7 +807,7 @@ class Satellite:
                         "There was an error running the stat function on this file",
                         filedir=ff,
                         file_num=n,
-                        err=e,
+                        err=traceback.format_exception(e),
                     )
                     n: int = (n + i) % 0xFFFF
                     # print('file number is',n)
@@ -796,6 +823,9 @@ class Satellite:
             return ff
         except Exception as e:
             self.logger.error(
-                "Error creating file", filedir=ff, err=e, binary_mode=binary
+                "Error creating file",
+                filedir=ff,
+                err=traceback.format_exception(e),
+                binary_mode=binary,
             )
             return None

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -10,7 +10,6 @@ Library Repo:
 # Common CircuitPython Libs
 import sys
 import time
-import traceback
 from collections import OrderedDict
 from os import chdir, mkdir, stat
 
@@ -84,7 +83,7 @@ class Satellite:
                 self.logger.error(
                     "There was an error initializing this hardware component",
                     hardware_key=hardware_key,
-                    err=traceback.format_exception(e),
+                    err=e,
                 )
             return None
 
@@ -453,7 +452,7 @@ class Satellite:
                 self.logger.error(
                     "There was an Exception during the scan_tca_channels function call",
                     face=channel_to_face[channel],
-                    err=traceback.format_exception(e),
+                    err=e,
                 )
 
     def _scan_single_channel(
@@ -484,7 +483,7 @@ class Satellite:
             self.logger.error(
                 "There was an Exception during the _scan_single_channel function call",
                 face=channel_to_face[channel],
-                err=traceback.format_exception(e),
+                err=e,
             )
         finally:
             self.tca[channel].unlock()
@@ -508,10 +507,7 @@ class Satellite:
                 machine.set_clock(62500000)  # 62.5Mhz
 
         except Exception as e:
-            self.logger.error(
-                "There was an error trying to set the clock",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("There was an error trying to set the clock", err=e)
 
     @property
     def RGB(self) -> tuple[int, int, int]:
@@ -529,7 +525,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error trying to set the new RGB value",
-                err=traceback.format_exception(e),
+                err=e,
                 value=value,
             )
 
@@ -546,28 +542,20 @@ class Satellite:
                 umount("/sd")
                 time.sleep(3)
             except Exception as e:
-                self.logger.error(
-                    "There was an error unmounting the SD card",
-                    err=traceback.format_exception(e),
-                )
+                self.logger.error("There was an error unmounting the SD card", err=e)
         try:
             self.logger.debug(
                 "Resetting VBUS [IMPLEMENT NEW FUNCTION HERE]",
             )
         except Exception as e:
-            self.logger.error(
-                "There was a vbus reset error", err=traceback.format_exception(e)
-            )
+            self.logger.error("There was a vbus reset error", err=e)
 
     @property
     def gyro(self) -> Union[tuple[float, float, float], None]:
         try:
             return self.imu.gyro
         except Exception as e:
-            self.logger.error(
-                "There was an error retrieving the gyro values",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("There was an error retrieving the gyro values", err=e)
 
     @property
     def accel(self) -> Union[tuple[float, float, float], None]:
@@ -575,8 +563,7 @@ class Satellite:
             return self.imu.acceleration
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the accelerometer values",
-                err=traceback.format_exception(e),
+                "There was an error retrieving the accelerometer values", err=e
             )
 
     @property
@@ -585,8 +572,7 @@ class Satellite:
             return self.imu.temperature
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the internal temperature value",
-                err=traceback.format_exception(e),
+                "There was an error retrieving the internal temperature value", err=e
             )
 
     @property
@@ -595,8 +581,7 @@ class Satellite:
             return self.mangetometer.magnetic
         except Exception as e:
             self.logger.error(
-                "There was an error retrieving the magnetometer sensor values",
-                err=traceback.format_exception(e),
+                "There was an error retrieving the magnetometer sensor values", err=e
             )
 
     @property
@@ -604,10 +589,7 @@ class Satellite:
         try:
             return self.rtc.get_time()
         except Exception as e:
-            self.logger.error(
-                "There was an error retrieving the RTC time",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("There was an error retrieving the RTC time", err=e)
 
     @time.setter
     def time(self, hms: tuple[int, int, int]) -> None:
@@ -624,7 +606,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error setting the RTC time",
-                err=traceback.format_exception(e),
+                err=e,
                 hms=hms,
                 hour=hms[0],
                 minutes=hms[1],
@@ -636,10 +618,7 @@ class Satellite:
         try:
             return self.rtc.get_date()
         except Exception as e:
-            self.logger.error(
-                "There was an error retrieving RTC date",
-                err=traceback.format_exception(e),
-            )
+            self.logger.error("There was an error retrieving RTC date", err=e)
 
     @date.setter
     def date(self, ymdw: tuple[int, int, int, int]) -> None:
@@ -656,7 +635,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an error setting the RTC date",
-                err=traceback.format_exception(e),
+                err=e,
                 ymdw=ymdw,
                 year=ymdw[0],
                 month=ymdw[1],
@@ -707,7 +686,7 @@ class Satellite:
         except Exception as e:
             self.logger.error(
                 "There was an Error in changing operations of powermode",
-                err=traceback.format_exception(e),
+                err=e,
                 mode=mode,
             )
 
@@ -731,10 +710,7 @@ class Satellite:
                         self.logger.info(line.strip())
         except Exception as e:
             self.logger.error(
-                "Can't print file",
-                filedir=filedir,
-                err=traceback.format_exception(e),
-                binary_mode=binary,
+                "Can't print file", filedir=filedir, err=e, binary_mode=binary
             )
 
     def read_file(
@@ -755,10 +731,7 @@ class Satellite:
                     return file
         except Exception as e:
             self.logger.error(
-                "Can't read file",
-                filedir=filedir,
-                err=traceback.format_exception(e),
-                binary_mode=binary,
+                "Can't read file", filedir=filedir, err=e, binary_mode=binary
             )
 
     def new_file(self, substring: str, binary: bool = False) -> Union[str, None]:
@@ -793,7 +766,7 @@ class Satellite:
                 except Exception as e:
                     self.logger.error(
                         "Error with creating new file",
-                        err=traceback.format_exception(e),
+                        err=e,
                         filedir="/sd" + _folder,
                     )
                     return None
@@ -807,7 +780,7 @@ class Satellite:
                         "There was an error running the stat function on this file",
                         filedir=ff,
                         file_num=n,
-                        err=traceback.format_exception(e),
+                        err=e,
                     )
                     n: int = (n + i) % 0xFFFF
                     # print('file number is',n)
@@ -823,9 +796,6 @@ class Satellite:
             return ff
         except Exception as e:
             self.logger.error(
-                "Error creating file",
-                filedir=ff,
-                err=traceback.format_exception(e),
-                binary_mode=binary,
+                "Error creating file", filedir=ff, err=e, binary_mode=binary
             )
             return None

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -446,7 +446,7 @@ class Satellite:
                 self._scan_single_channel(channel, channel_to_face)
             except OSError as os_error:
                 self.logger.error(
-                    "TCA try_lock failed. TCA may be malfunctioning.", err=os_error
+                    "TCA try_lock failed. TCA may be malfunctioning.", os_error
                 )
                 self.hardware["TCA"] = False
                 return

--- a/main.py
+++ b/main.py
@@ -150,4 +150,4 @@ try:
         c.hardware["WDT"] = False
 
 except Exception as e:
-    logger.error("An exception occured within main.py", e)
+    logger.critical("An exception occured within main.py", e)

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ try:
         initial_boot()
 
     except Exception as e:
-        logger.error("Error in Boot Sequence", err=e)
+        logger.error("Error in Boot Sequence", e)
 
     finally:
         pass
@@ -139,7 +139,7 @@ try:
                 f.listen()
 
     except Exception as e:
-        logger.critical("Critical in Main Loop", err=e)
+        logger.critical("Critical in Main Loop", e)
         time.sleep(10)
         microcontroller.on_next_reset(microcontroller.RunMode.NORMAL)
         microcontroller.reset()
@@ -150,4 +150,4 @@ try:
         c.hardware["WDT"] = False
 
 except Exception as e:
-    logger.error("An exception occured within main.py", err=e)
+    logger.error("An exception occured within main.py", e)

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ Published: Nov 19, 2024
 """
 
 import time
-import traceback
 
 import microcontroller
 
@@ -65,7 +64,7 @@ try:
         initial_boot()
 
     except Exception as e:
-        logger.error("Error in Boot Sequence", err=traceback.format_exception(e))
+        logger.error("Error in Boot Sequence", err=e)
 
     finally:
         pass
@@ -140,7 +139,7 @@ try:
                 f.listen()
 
     except Exception as e:
-        logger.critical("Critical in Main Loop", err=traceback.format_exception(e))
+        logger.critical("Critical in Main Loop", err=e)
         time.sleep(10)
         microcontroller.on_next_reset(microcontroller.RunMode.NORMAL)
         microcontroller.reset()
@@ -151,6 +150,4 @@ try:
         c.hardware["WDT"] = False
 
 except Exception as e:
-    logger.critical(
-        "An exception occured within main.py", err=traceback.format_exception(e)
-    )
+    logger.error("An exception occured within main.py", err=e)

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ Published: Nov 19, 2024
 """
 
 import time
+import traceback
 
 import microcontroller
 
@@ -64,7 +65,7 @@ try:
         initial_boot()
 
     except Exception as e:
-        logger.error("Error in Boot Sequence", err=e)
+        logger.error("Error in Boot Sequence", err=traceback.format_exception(e))
 
     finally:
         pass
@@ -139,7 +140,7 @@ try:
                 f.listen()
 
     except Exception as e:
-        logger.critical("Critical in Main Loop", err=e)
+        logger.critical("Critical in Main Loop", err=traceback.format_exception(e))
         time.sleep(10)
         microcontroller.on_next_reset(microcontroller.RunMode.NORMAL)
         microcontroller.reset()
@@ -150,4 +151,6 @@ try:
         c.hardware["WDT"] = False
 
 except Exception as e:
-    logger.error("An exception occured within main.py", err=e)
+    logger.critical(
+        "An exception occured within main.py", err=traceback.format_exception(e)
+    )

--- a/tests/unit/lib/pysquared/test_logger.py
+++ b/tests/unit/lib/pysquared/test_logger.py
@@ -21,17 +21,47 @@ def test_debug_log(capsys, logger):
     assert '"blake": "jameson"' in captured.out
 
 
+def test_debug_with_err(capsys, logger):
+    logger.debug(
+        "This is another debug message", err=OSError("Manually creating an OS Error")
+    )
+    captured = capsys.readouterr()
+    assert "DEBUG" in captured.out
+    assert "This is another debug message" in captured.out
+    assert "OSError: Manually creating an OS Error" in captured.out
+
+
 def test_info_log(capsys, logger):
-    logger.info("This is a info message!!", foo="bar")
+    logger.info(
+        "This is a info message!!",
+        foo="bar",
+    )
     captured = capsys.readouterr()
     assert "INFO" in captured.out
     assert "This is a info message!!" in captured.out
     assert '"foo": "bar"' in captured.out
 
 
+def test_info_with_err(capsys, logger):
+    logger.info(
+        "This is a info message!!",
+        foo="barrrr",
+        err=OSError("Manually creating an OS Error"),
+    )
+    captured = capsys.readouterr()
+    assert "INFO" in captured.out
+    assert "This is a info message!!" in captured.out
+    assert '"foo": "barrrr"' in captured.out
+    assert "OSError: Manually creating an OS Error" in captured.out
+
+
 def test_warning_log(capsys, logger):
     logger.warning(
-        "This is a warning message!!??!", boo="bar", pleiades="maia", cube="sat"
+        "This is a warning message!!??!",
+        boo="bar",
+        pleiades="maia",
+        cube="sat",
+        err=Exception("manual exception"),
     )
     captured = capsys.readouterr()
     assert "WARNING" in captured.out
@@ -39,12 +69,13 @@ def test_warning_log(capsys, logger):
     assert '"boo": "bar"' in captured.out
     assert '"pleiades": "maia"' in captured.out
     assert '"cube": "sat"' in captured.out
+    assert "Exception: manual exception" in captured.out
 
 
 def test_error_log(capsys, logger):
     logger.error(
         "This is an error message",
-        err=OSError("Manually creating an OS Error for testing"),
+        OSError("Manually creating an OS Error for testing"),
         hee="haa",
         pleiades="five",
         please="work",
@@ -56,17 +87,12 @@ def test_error_log(capsys, logger):
     assert '"pleiades": "five"' in captured.out
     assert '"please": "work"' in captured.out
     assert "OSError: Manually creating an OS Error for testing" in captured.out
-    # assert '{"type": "OS Error"' in captured.out
-    assert (
-        '"err": {"type": "OSError", "message": "Manually creating an OS Error for testing'
-        in captured.out
-    )
 
 
 def test_critical_log(capsys, logger):
     logger.critical(
         "THIS IS VERY CRITICAL",
-        err=OSError("Manually creating an OS Error"),
+        OSError("Manually creating an OS Error"),
         ad="astra",
         space="lab",
         soft="ware",
@@ -82,7 +108,3 @@ def test_critical_log(capsys, logger):
     assert '"j": "20"' in captured.out
     assert '"config": "king"' in captured.out
     assert "OSError: Manually creating an OS Error" in captured.out
-    assert (
-        '"err": {"type": "OSError", "message": "Manually creating an OS Error'
-        in captured.out
-    )

--- a/tests/unit/lib/pysquared/test_logger.py
+++ b/tests/unit/lib/pysquared/test_logger.py
@@ -54,8 +54,13 @@ def test_error_log(capsys, logger):
     assert "This is an error message" in captured.out
     assert '"hee": "haa"' in captured.out
     assert '"pleiades": "five"' in captured.out
-    assert "OSError: Manually creating an OS Error for testing" in captured.out
     assert '"please": "work"' in captured.out
+    assert "OSError: Manually creating an OS Error for testing" in captured.out
+    # assert '{"type": "OS Error"' in captured.out
+    assert (
+        '"err": {"type": "OSError", "message": "Manually creating an OS Error for testing'
+        in captured.out
+    )
 
 
 def test_critical_log(capsys, logger):
@@ -77,3 +82,7 @@ def test_critical_log(capsys, logger):
     assert '"j": "20"' in captured.out
     assert '"config": "king"' in captured.out
     assert "OSError: Manually creating an OS Error" in captured.out
+    assert (
+        '"err": {"type": "OSError", "message": "Manually creating an OS Error'
+        in captured.out
+    )

--- a/tests/unit/lib/pysquared/test_logger.py
+++ b/tests/unit/lib/pysquared/test_logger.py
@@ -42,18 +42,26 @@ def test_warning_log(capsys, logger):
 
 
 def test_error_log(capsys, logger):
-    logger.error("This is an error message", hee="haa", pleiades="five", please="work")
+    logger.error(
+        "This is an error message",
+        err=OSError("Manually creating an OS Error for testing"),
+        hee="haa",
+        pleiades="five",
+        please="work",
+    )
     captured = capsys.readouterr()
     assert "ERROR" in captured.out
     assert "This is an error message" in captured.out
     assert '"hee": "haa"' in captured.out
     assert '"pleiades": "five"' in captured.out
+    assert "OSError: Manually creating an OS Error for testing" in captured.out
     assert '"please": "work"' in captured.out
 
 
 def test_critical_log(capsys, logger):
     logger.critical(
         "THIS IS VERY CRITICAL",
+        err=OSError("Manually creating an OS Error"),
         ad="astra",
         space="lab",
         soft="ware",
@@ -68,3 +76,4 @@ def test_critical_log(capsys, logger):
     assert '"soft": "ware"' in captured.out
     assert '"j": "20"' in captured.out
     assert '"config": "king"' in captured.out
+    assert "OSError: Manually creating an OS Error" in captured.out


### PR DESCRIPTION
## Summary
In the Logger class, I replaced the "err" so that the value for the json output will equal traceback.format_exception(e), whereas previously "err" equaled the value of the error e. Using the format_exception() is more descriptive, as it shows the call stack.

Following Nate's advice, I also added a check for the non error severity levels (debug, info, and warning) to see if those function calls pass an argument "err" of type Exception to the kwargs. If the user does happen to pass that, the "err" json output is formatted appropriately with traceback.format_exception().

## How was this tested
- [x] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)

Here is output of the code working on a v4b board, similar output to the main branch. However, it of course has the updated "err" value with the traceback.
<img width="1711" alt="Screenshot 2025-02-13 at 9 12 29 PM" src="https://github.com/user-attachments/assets/ad96104f-1d38-45a0-bfde-3cd1c90d5ffc" />

Here is the code and output if someone uses the debug log call yet passes an Exception to a kwarg value of "err". As you can see, it formats the "err" value as a traceback
<img width="684" alt="Screenshot 2025-02-13 at 8 56 31 PM" src="https://github.com/user-attachments/assets/358793ef-19fe-497f-aa26-8f6f017075d8" />
<img width="1707" alt="Screenshot 2025-02-13 at 8 57 47 PM" src="https://github.com/user-attachments/assets/d3c17965-64b7-4810-bc6a-8f179b95f029" />

Here is the code and output if someone uses the debug log call but passes a string value to a kwarg value of "err". As you can see, it formats the "err" value as a string
<img width="916" alt="Screenshot 2025-02-13 at 8 58 15 PM" src="https://github.com/user-attachments/assets/8b4c8c13-1288-4a5c-bb23-8c3b8ecc4665" />
<img width="1709" alt="Screenshot 2025-02-13 at 8 59 37 PM" src="https://github.com/user-attachments/assets/d280a93a-9682-44fb-a064-3ec33cbbff31" />