### PR TITLE
Add SonarQube test coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Archive coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report.xml
+          name: coverage-report
           path: .coverage-reports/coverage.xml
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v4.2.1
@@ -43,5 +43,5 @@ jobs:
       - name: Archive
         uses: actions/upload-artifact@v4
         with:
-          name: proves.zip
+          name: proves
           path: artifacts/proves.zip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Disabling shallow clones is recommended for improving the relevancy of SonarQube reporting
+          fetch-depth: 0
       - name: Test
         run: |
           make test
+      - name: Archive coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report.xml
+          path: .coverage-reports/coverage.xml
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   archive:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 .pytest_cache
 .coverage
+.coverage-reports/
 .DS_Store
 .venv
 artifacts/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,5 @@ include = [
     "safemode.py",
     ]
 
-[tool.coverage.html]
-directory = "coverage-reports/html"
-
 [tool.coverage.xml]
-output = "coverage-reports/coverage.xml"
+output = ".coverage-reports/coverage.xml"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.projectKey=circuitpy_flight_software
+sonar.organization=proves-kit
+
+sonar.python.coverage.reportPaths=.coverage-reports/coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=circuitpy_flight_software
+sonar.projectKey=proveskit_circuitpy_flight_software
 sonar.organization=proves-kit
 
 sonar.python.coverage.reportPaths=.coverage-reports/coverage.xml


### PR DESCRIPTION
## Summary
This PR adds code coverage information to sonarqube. I _think_ we need to merge it into `main` to start seeing it in the repo report.

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [x] Other (Please describe)
Looked at sonarqube quality gate messgae and see that code coverage is no longer reading as `No data about Coverage`
<img width="446" alt="Screenshot 2025-02-15 at 13 38 13" src="https://github.com/user-attachments/assets/1ca941dc-f3cc-4e75-b535-ac85665628fc" />
<img width="439" alt="Screenshot 2025-02-15 at 13 38 41" src="https://github.com/user-attachments/assets/d929dc13-cc02-4515-8238-070426b687aa" />
