### PR TITLE
updated requirements.txt to point to proveskit modified version of Adafruit_CircuitPython_TCA9548A

### DIFF
--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -7,6 +7,6 @@ adafruit-circuitpython-mcp9808==3.3.24
 adafruit-circuitpython-neopixel==6.3.12
 adafruit-circuitpython-register==1.10.1
 adafruit-circuitpython-rfm==1.0.3
-adafruit-circuitpython-tca9548a==0.7.4
+adafruit-circuitpython-tca9548a @ git+https://github.com/proveskit/Adafruit_CircuitPython_TCA9548A
 adafruit-circuitpython-ticks==1.1.1
 adafruit-circuitpython-veml7700==2.0.2


### PR DESCRIPTION
## Summary
Changed the requirements to now point to the proveskit modified version of `Adafruit_CircuitPython_TCA9548A` instead of the upstream. [Proveskit version of TCA9548A](https://github.com/proveskit/Adafruit_CircuitPython_TCA9548A)

Using `make install` will now result in the proveskit version being downloaded and loaded onto the board

## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)

As shown below, the program no longer stops at the Safe Sleep and proceeds to loop through the main loop over and over.

<img width="1293" alt="Screenshot 2025-02-17 at 4 03 56 PM" src="https://github.com/user-attachments/assets/05e91e2b-09e3-4973-96dc-6537852c5df7" />
<img width="1127" alt="Screenshot 2025-02-17 at 4 09 03 PM" src="https://github.com/user-attachments/assets/5fcb1697-926b-46ea-9e29-4ff431751e00" />