### PR TITLE
Fix sonar code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__/
 .pytest_cache
-.coverage
+.coverage*
 .coverage-reports/
 .DS_Store
 .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,15 @@ include = [
     "repl.py",
     "safemode.py",
     ]
+omit = [
+    "lib/adafruit_*/**",
+    "lib/asyncio_*/**",
+    "lib/rv3028*/**",
+    "lib/neopixel.py",
+    ]
+
+[tool.coverage.html]
+directory = ".coverage-reports/html"
 
 [tool.coverage.xml]
 output = ".coverage-reports/coverage.xml"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,7 @@
 sonar.projectKey=proveskit_circuitpy_flight_software
 sonar.organization=proves-kit
 
+sonar.sources=boot.py, main.py, repl.py, safemode.py, lib/pysquared/
+sonar.tests=mocks/, stubs/, tests/
+
 sonar.python.coverage.reportPaths=.coverage-reports/coverage.xml


### PR DESCRIPTION
## Summary
This PR fixes sonarqube test coverage. Currently test coverage metrics counts `tests/` `mocks/` and `stubs/` dirs against the coverage % and it shouldn't!

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [x] Other (Please describe)
Tested in #161 