### PR TITLE
Add circuitpython-stubs to venv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "adafruit-circuitpython-typing==1.11.2",
+    "circuitpython-stubs==9.2.4",
     "coverage==7.6.10",
     "pre-commit==4.0.1",
     "pytest==8.3.2",


### PR DESCRIPTION
## Summary
This package removes red squigggglies from IDEs and provides hints for circuitpython builtin imports like `microcontroller` and `alarm`

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [x] Other (Please describe)
Only runs in IDE.