### PR TITLE
Add version field to repl.py

### DIFF
--- a/repl.py
+++ b/repl.py
@@ -5,10 +5,11 @@ from lib.pysquared.config import Config
 from lib.pysquared.logger import Logger
 from lib.pysquared.nvm.counter import Counter
 from lib.pysquared.pysquared import Satellite
+from version import __version__
 
 logger: Logger = Logger(
     error_counter=Counter(index=register.ERRORCNT, datastore=microcontroller.nvm)
 )
 config: Config = Config("config.json")
 logger.info("Initializing a cubesat object as `c` in the REPL...")
-c: Satellite = Satellite(config, logger)
+c: Satellite = Satellite(config, logger, __version__)


### PR DESCRIPTION
## Summary
Oversight from the version pr, forgot to add the version to the Satellite class in repl.py, so it was erroring

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
