### PR TITLE
Removed supervisor.set_next_stack_limit() from boot.py

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,3 +1,0 @@
-import supervisor
-
-supervisor.set_next_stack_limit(4096 + 4096)


### PR DESCRIPTION
## Summary
I removed the `set_next_stack_limit()` call from boot.py

As mentioned in https://github.com/proveskit/circuitpy_flight_software/issues/180#issue-2895261546, the `set_next_stack_limit()` call was removed in CP 8.0.0. The following boot.txt output showed when running code on the board with that line in boot.py:
<img width="930" alt="Screenshot 2025-03-04 at 1 33 44 PM" src="https://github.com/user-attachments/assets/6369ee1c-fc78-4651-8cbf-cd6ed845957c" />

Then when using the property that replaced it in CP 8.0.0, `supervisor.runtime.next_stack_limit`, an error occurred as well. It looks like that property is no longer supported either in CP 9
<img width="725" alt="Screenshot 2025-03-04 at 2 47 41 PM" src="https://github.com/user-attachments/assets/b507b684-4631-4d97-bbae-ae1f2fd83eba" />

In following Michael's advice in https://github.com/proveskit/circuitpy_flight_software/issues/180#issuecomment-2698768875, "It might be best at this point to just get rid of this functional call and not think too much about memory manipulation at this stage", I am removing the function call in this PR.

Just to be safe, I ran the code on the board with this change and it runs as normal:
<img width="1137" alt="Screenshot 2025-03-04 at 3 00 33 PM" src="https://github.com/user-attachments/assets/df732797-fe3b-421b-9ae4-f30daaf33767" />

## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
