### PR TITLE
170-2 Split from pysquared, add tests, add test debug to launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Unit test",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/.venv/bin/pytest",
+            "args": [
+                "tests/unit",
+                "--maxfail=1",
+                "--disable-warnings"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,9 @@
         "tests/unit"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "sonarlint.connectedMode.project": {
+        "connectionId": "proves-kit",
+        "projectKey": "proveskit_circuitpy_flight_software"
+    }
 }

--- a/lib/pysquared/pysquared.py
+++ b/lib/pysquared/pysquared.py
@@ -18,7 +18,6 @@ import busio
 import digitalio
 import machine
 import microcontroller
-import rtc
 import sdcardio
 from micropython import const
 from storage import VfsFat, mount, umount
@@ -741,31 +740,3 @@ class Satellite:
         except Exception as e:
             self.logger.error("Error creating file", e, filedir=ff, binary_mode=binary)
             return None
-
-
-def set_rp2040_rtc_time(
-    year: int,
-    month: int,
-    date: int,
-    hour: int,
-    minute: int,
-    second: int,
-    day_of_week: int,
-):
-    """
-    Updates the RP2040's Real Time Clock (RTC) to the date and time passed
-
-    :param year: The year value (0-9999)
-    :param month: The month value (1-12)
-    :param date: The date value (1-31)
-    :param hour: The hour value (0-23)
-    :param minute: The minute value (0-59)
-    :param second: The second value (0-59)
-    :param day_of_week: The nth day of the week (0-6), where 0 represents Sunday and 6 represents Saturday
-    """
-
-    # Accessing the RP2040's RTC and updating its current date, time
-    rp2040_rtc = rtc.RTC()
-    rp2040_rtc.datetime = time.struct_time(
-        (year, month, date, hour, minute, second, day_of_week, -1, -1)
-    )

--- a/lib/pysquared/rtc/rp2040.py
+++ b/lib/pysquared/rtc/rp2040.py
@@ -1,0 +1,38 @@
+import time
+
+try:
+    import rtc
+except ImportError:
+    import mocks.circuitpython.rtc as rtc
+
+
+class RP2040RTC:
+    """
+    Class for interfacing with the RP2040's Real Time Clock (RTC)
+    """
+
+    @staticmethod
+    def set_time(
+        year: int,
+        month: int,
+        date: int,
+        hour: int,
+        minute: int,
+        second: int,
+        day_of_week: int,
+    ) -> None:
+        """
+        Updates the RP2040's Real Time Clock (RTC) to the date and time passed
+
+        :param year: The year value (0-9999)
+        :param month: The month value (1-12)
+        :param date: The date value (1-31)
+        :param hour: The hour value (0-23)
+        :param minute: The minute value (0-59)
+        :param second: The second value (0-59)
+        :param day_of_week: The nth day of the week (0-6), where 0 represents Sunday and 6 represents Saturday
+        """
+        rp2040_rtc = rtc.RTC()
+        rp2040_rtc.datetime = time.struct_time(
+            (year, month, date, hour, minute, second, day_of_week, -1, -1)
+        )

--- a/lib/pysquared/rtc/rtc_common.py
+++ b/lib/pysquared/rtc/rtc_common.py
@@ -20,4 +20,3 @@ class RTC:
         """
         rp2040_rtc = rtc.RTC()
         rp2040_rtc.datetime = time.localtime()
-        print(f"RTC initialized with time: {rp2040_rtc.datetime}")

--- a/lib/pysquared/rtc/rtc_common.py
+++ b/lib/pysquared/rtc/rtc_common.py
@@ -1,0 +1,23 @@
+import time
+
+try:
+    import rtc
+except ImportError:
+    import mocks.circuitpython.rtc as rtc
+
+
+class RTC:
+    """
+    Common class for interfacing with the Real Time Clock (RTC)
+    """
+
+    @staticmethod
+    def init() -> None:
+        """
+        Initialize the RTC
+
+        Required on every boot to ensure the RTC is ready for use
+        """
+        rp2040_rtc = rtc.RTC()
+        rp2040_rtc.datetime = time.localtime()
+        print(f"RTC initialized with time: {rp2040_rtc.datetime}")

--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ import time
 import board
 import digitalio
 import microcontroller
-import rtc
 
 import lib.pysquared.functions as functions
 import lib.pysquared.nvm.register as register
@@ -26,15 +25,11 @@ from lib.pysquared.hardware.rfm9x.manager import RFM9xManager
 from lib.pysquared.logger import Logger
 from lib.pysquared.nvm.counter import Counter
 from lib.pysquared.nvm.flag import Flag
+from lib.pysquared.rtc.rtc_common import RTC
 from lib.pysquared.sleep_helper import SleepHelper
 from version import __version__
 
-rp2040_rtc = rtc.RTC()
-# This line below allows the RP2040's RTC to capture the updated time
-# and date passed in the set_rp2040_rtc_time in the REPL when rebooting.
-# Without this line, the program will hang at the first safe sleep after updating the
-# RP2040's RTC
-rp2040_rtc.datetime = time.localtime()
+RTC.init()
 
 logger: Logger = Logger(
     error_counter=Counter(index=register.ERRORCNT, datastore=microcontroller.nvm),

--- a/mocks/circuitpython/rtc.py
+++ b/mocks/circuitpython/rtc.py
@@ -1,0 +1,8 @@
+class RTC:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(RTC, cls).__new__(cls)
+            cls._instance.datetime = None
+        return cls._instance

--- a/mocks/circuitpython/rtc.py
+++ b/mocks/circuitpython/rtc.py
@@ -6,3 +6,7 @@ class RTC:
             cls._instance = super(RTC, cls).__new__(cls)
             cls._instance.datetime = None
         return cls._instance
+
+    @classmethod
+    def destroy(cls):
+        cls._instance = None

--- a/tests/unit/lib/pysquared/rtc/test_rp2040.py
+++ b/tests/unit/lib/pysquared/rtc/test_rp2040.py
@@ -1,7 +1,15 @@
 import time
 
+import pytest
+
 import mocks.circuitpython.rtc as MockRTC
 from lib.pysquared.rtc.rp2040 import RP2040RTC
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    MockRTC.RTC().destroy()
 
 
 def test_set_time():

--- a/tests/unit/lib/pysquared/rtc/test_rp2040.py
+++ b/tests/unit/lib/pysquared/rtc/test_rp2040.py
@@ -1,0 +1,33 @@
+import time
+
+import mocks.circuitpython.rtc as MockRTC
+from lib.pysquared.rtc.rp2040 import RP2040RTC
+
+
+def test_set_time():
+    """Test that the RP2040RTC.set_time method correctly sets RTC.datetime"""
+    year = 2025
+    month = 3
+    day = 6
+    hour = 10
+    minute = 30
+    second = 45
+    day_of_week = 2
+
+    # Set the time using the RP2040RTC class
+    RP2040RTC.set_time(year, month, day, hour, minute, second, day_of_week)
+
+    # Get the mock RTC instance and check its datetime
+    mrtc: MockRTC = MockRTC.RTC()
+    assert mrtc.datetime is not None, "Mock RTC datetime should be set"
+    assert isinstance(
+        mrtc.datetime, time.struct_time
+    ), "Mock RTC datetime should be a time.struct_time instance"
+
+    assert mrtc.datetime.tm_year == year, "Year should match"
+    assert mrtc.datetime.tm_mon == month, "Month should match"
+    assert mrtc.datetime.tm_mday == day, "Day should match"
+    assert mrtc.datetime.tm_hour == hour, "Hour should match"
+    assert mrtc.datetime.tm_min == minute, "Minute should match"
+    assert mrtc.datetime.tm_sec == second, "Second should match"
+    assert mrtc.datetime.tm_wday == day_of_week, "Day of week should match"

--- a/tests/unit/lib/pysquared/rtc/test_rtc_common.py
+++ b/tests/unit/lib/pysquared/rtc/test_rtc_common.py
@@ -1,0 +1,15 @@
+import time
+
+import mocks.circuitpython.rtc as MockRTC
+from lib.pysquared.rtc.rtc_common import RTC
+
+
+def test_init():
+    """Test that the RTC.datetime is initialized with a time.struct_time"""
+    RTC.init()
+
+    mrtc: MockRTC = MockRTC.RTC()
+    assert mrtc.datetime is not None, "Mock RTC datetime should be set"
+    assert isinstance(
+        mrtc.datetime, time.struct_time
+    ), "Mock RTC datetime should be a time.struct_time instance"

--- a/tests/unit/lib/pysquared/rtc/test_rtc_common.py
+++ b/tests/unit/lib/pysquared/rtc/test_rtc_common.py
@@ -1,7 +1,15 @@
 import time
 
+import pytest
+
 import mocks.circuitpython.rtc as MockRTC
 from lib.pysquared.rtc.rtc_common import RTC
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    MockRTC.RTC().destroy()
 
 
 def test_init():

--- a/uv.lock
+++ b/uv.lock
@@ -116,6 +116,7 @@ version = "2.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "adafruit-circuitpython-typing" },
+    { name = "circuitpython-stubs" },
     { name = "coverage" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -124,9 +125,19 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "adafruit-circuitpython-typing", specifier = "==1.11.2" },
+    { name = "circuitpython-stubs", specifier = "==9.2.4" },
     { name = "coverage", specifier = "==7.6.10" },
     { name = "pre-commit", specifier = "==4.0.1" },
     { name = "pytest", specifier = "==8.3.2" },
+]
+
+[[package]]
+name = "circuitpython-stubs"
+version = "9.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/d2/51cc14e067cdc238c3c1cd22c098f372e71250c0454bb16aa8aef833fbfa/circuitpython_stubs-9.2.4.tar.gz", hash = "sha256:3e8c0ffc364686dd1102b6c6c41c4326e58cf50adc75432d43baaba5a8bb2af3", size = 338129 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/4b/784fe1eed79c2a310e45041765e94f9d00d89e9ef5960748407cbdf23151/circuitpython_stubs-9.2.4-py3-none-any.whl", hash = "sha256:03c466650e19c22b4d6c13a6e83b8a2d48031a9500c0bebadb7593c389270ed2", size = 977428 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR modifies #179 to split functionality out of pysquared. This allows us to more easily add tests (although adding tests for the RTC was a little challenging). I'm not sure if organization in the `rtc` module is overkill but feels OK for now. Added a debug config to help diagnose testing issues.

**Testing Challenges:**
I had some issues deciding on which components in this test to mock and how to mock them. I started with trying to test the `rtc_common.py` file which I felt was simpler since we only needed to know if the fns had been called not concerning ourselves with setting any values.

I first attempted to use MagicMock's call counter but had difficulty patching the `rtc` module since it was a singleton. Next I tried to create my own RTC mock and found that mocking out the singleton was a little challenging. Success only came from dropping into the debugger to walk through the tests and ensure we weren't using the same memory address between tests among many other issues I encountered.

Even though these tests were challenging to create the result is appears to be simple and _should_ require little maintenance 🤞.

## How was this tested
- [x] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
