### PR TITLE
Fixed Missing `code.py`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ ifeq ($(OS),Windows_NT)
 	rm -rf $(BOARD_MOUNT_POINT)
 	cp -r artifacts/proves/* $(BOARD_MOUNT_POINT)
 else
+	@rm $(BOARD_MOUNT_POINT)/code.py > /dev/null 2>&1 || true
 	$(call rsync_to_dest,$(BOARD_MOUNT_POINT))
 endif
 

--- a/code.py
+++ b/code.py
@@ -1,0 +1,1 @@
+import main  # noqa: F401

--- a/code.py
+++ b/code.py
@@ -1,1 +1,0 @@
-import main  # noqa: F401


### PR DESCRIPTION
## Summary
When using code from the `main` branch, nothing happens when you do a `make install` on a clean board.

I'm not sure when it happened, but somehow `code.py` got nuked from the `main` branch. This is an issue because on clean installs of the CircuitPython Firmware a `code.py`with only a `print("Hello World") statement is generated automagically.

Because `make install` doesn't overwrite this `code.py` with anything on startup the board will only execute the contents of `code.py` and exit to the REPL without executing any of the code in `main.py`. If this is the intended behavior we need to document it as such, but I suspect this is not intended behavior because if you attempt to `import main` from the REPL it will throw a critical `WDT_WDI in use` error:

<img width="1684" alt="Screenshot 2025-03-07 at 4 12 57 PM" src="https://github.com/user-attachments/assets/5814d10f-11a3-42d0-bafe-286447b82a68" />

With this patch we go back to normal functionality.

## How was this tested
- [ ] Added new unit tests
- [X] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)

## Adafruit Context
https://learn.adafruit.com/welcome-to-circuitpython/creating-and-editing-code

<img width="975" alt="Screenshot 2025-03-07 at 4 18 01 PM" src="https://github.com/user-attachments/assets/8ba0691e-80f9-4402-b625-dd226f28d11a" />