### PR TITLE
rm code.py in make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ ifeq ($(OS),Windows_NT)
 	rm -rf $(BOARD_MOUNT_POINT)
 	cp -r artifacts/proves/* $(BOARD_MOUNT_POINT)
 else
+	@rm $(BOARD_MOUNT_POINT)/code.py > /dev/null 2>&1 || true
 	$(call rsync_to_dest,$(BOARD_MOUNT_POINT))
 endif
 

--- a/code.py
+++ b/code.py
@@ -1,1 +1,0 @@
-import main  # noqa: F401


### PR DESCRIPTION
## Summary
Unfortunately, it looks like Python has a built-in module called `code` which causes the IDE to freak out a bit.
<img width="774" alt="Screenshot 2025-03-08 at 10 46 34" src="https://github.com/user-attachments/assets/87b4a2bd-cab2-4fed-872b-10b9bd800f90" />

It also seems to prevent our code coverage analysis from running.
<img width="1440" alt="Screenshot 2025-03-08 at 15 19 46" src="https://github.com/user-attachments/assets/e462effd-2527-45f1-8ca4-fd70aab1f4a7" />
https://github.com/proveskit/circuitpy_flight_software/actions/runs/13731659762/job/38429209618

One option is to delete `code.py` while running `make install`. Not perfect but might do in a pinch. What do you think @Mikefly123 

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
