### PR TITLE
moved gc .collect() in order for the free memory stat to be more accurate

### DIFF
--- a/lib/pysquared/functions.py
+++ b/lib/pysquared/functions.py
@@ -260,11 +260,11 @@ class functions:
 
     def all_face_data(self) -> list:
         # self.cubesat.all_faces_on()
+        gc.collect()
         self.logger.debug(
             "Free Memory Stat at beginning of all_face_data function",
             bytes_free=gc.mem_free(),
         )
-        gc.collect()
 
         try:
             import lib.pysquared.Big_Data as Big_Data


### PR DESCRIPTION
## Summary
Previously, the "Free Memory Stat at beginning of all_face_data function" call showed bytes_free to be low. Not only was it low but it was also lower than the subsequent call of bytes_free for "Memory Stat after importing Big_data library". See https://github.com/proveskit/circuitpy_flight_software/issues/195#issue-2917934904 for the previous behavior 

I realized that the gc.collect() wasn't called until after the "Free Memory Stat at beginning of all_face_data function" line was logged, so the "Free Memory Stat at beginning of all_face_data function" line wasn't accurate, as the existing garbage hadn't been collected.

With the change I made, now the "Free Memory Stat at beginning of all_face_data function" line is accurate, as it truly represents how much memory is currently available, as garbage had been collected a line above.

The new output of "Free Memory Stat at beginning of all_face_data function" making the change I did:
<img width="973" alt="Screenshot 2025-03-13 at 12 48 12 PM" src="https://github.com/user-attachments/assets/6cf2f72e-fcaa-47d6-9edd-938215d63dbe" />
<img width="967" alt="Screenshot 2025-03-13 at 12 42 26 PM" src="https://github.com/user-attachments/assets/f2f2570a-c280-47fb-993f-71ca8560326f" />
<img width="963" alt="Screenshot 2025-03-13 at 12 39 06 PM" src="https://github.com/user-attachments/assets/2c3df2b1-be77-4e89-a2ca-e8cd5318eac1" />
<img width="954" alt="Screenshot 2025-03-13 at 12 35 47 PM" src="https://github.com/user-attachments/assets/0c092797-a808-42e9-b4a9-e22881b684da" />


## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
