### PR TITLE
Disable color logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ RTC.init()
 
 logger: Logger = Logger(
     error_counter=Counter(index=register.ERRORCNT, datastore=microcontroller.nvm),
-    colorized=True,
+    colorized=False,
 )
 
 logger.info("Booting", software_version=__version__, published_date="November 19, 2024")

--- a/repl.py
+++ b/repl.py
@@ -9,7 +9,7 @@ from version import __version__
 
 logger: Logger = Logger(
     error_counter=Counter(index=register.ERRORCNT, datastore=microcontroller.nvm),
-    colorized=True,
+    colorized=False,
 )
 config: Config = Config("config.json")
 logger.info("Initializing a cubesat object as `c` in the REPL...")


### PR DESCRIPTION
## Summary
When I was working on the ground station software and pulled the new changes onto a board, I noticed that the colored logging breaks the formatted output because the coloring adds certain strings for the terminal to parse for color. Figure this will be the much easier route instead of trying to parse it in the ground station software.
<img width="1414" alt="image" src="https://github.com/user-attachments/assets/a94d8a7e-5b94-4625-badb-2640c3f7716a" />


## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
