### PR TITLE
Use circuitpython 9.2.5 for v4 board stubs

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,9 +11,13 @@ Published: Nov 19, 2024
 import gc
 import time
 
-import board
 import digitalio
 import microcontroller
+
+try:
+    from board_definitions import proveskit_rp2040_v4 as board
+except ImportError:
+    import board
 
 import lib.pysquared.functions as functions
 import lib.pysquared.nvm.register as register

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "adafruit-circuitpython-typing==1.11.2",
-    "circuitpython-stubs==9.2.4",
+    "circuitpython-stubs==9.2.5",
     "coverage==7.6.10",
     "pre-commit==4.0.1",
     "pytest==8.3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "adafruit-circuitpython-typing", specifier = "==1.11.2" },
-    { name = "circuitpython-stubs", specifier = "==9.2.4" },
+    { name = "circuitpython-stubs", specifier = "==9.2.5" },
     { name = "coverage", specifier = "==7.6.10" },
     { name = "pre-commit", specifier = "==4.0.1" },
     { name = "pytest", specifier = "==8.3.2" },
@@ -133,11 +133,11 @@ requires-dist = [
 
 [[package]]
 name = "circuitpython-stubs"
-version = "9.2.4"
+version = "9.2.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/d2/51cc14e067cdc238c3c1cd22c098f372e71250c0454bb16aa8aef833fbfa/circuitpython_stubs-9.2.4.tar.gz", hash = "sha256:3e8c0ffc364686dd1102b6c6c41c4326e58cf50adc75432d43baaba5a8bb2af3", size = 338129 }
+sdist = { url = "https://files.pythonhosted.org/packages/07/d7/ce0a51ba9f6b15bdde6a79cfa96f3c63117dd749465be18980461771cfa9/circuitpython_stubs-9.2.5.tar.gz", hash = "sha256:2b2be4172552bdb9c5a1e9923124ee62f0bed4c0b128d862ad1baf8866e67174", size = 348760 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/4b/784fe1eed79c2a310e45041765e94f9d00d89e9ef5960748407cbdf23151/circuitpython_stubs-9.2.4-py3-none-any.whl", hash = "sha256:03c466650e19c22b4d6c13a6e83b8a2d48031a9500c0bebadb7593c389270ed2", size = 977428 },
+    { url = "https://files.pythonhosted.org/packages/c7/27/72e6715132a325db32ff06475c7da1a217e65082d710b1a7e8ce3c36ca0e/circuitpython_stubs-9.2.5-py3-none-any.whl", hash = "sha256:9b2e8ba04e7fee6a0155e5915b36a1a911e2e3486c795669baa9c2db76102a7c", size = 1006110 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR updates the board import in `main.py` to use the upstream board stub in the IDE. We can now see exactly which pins are available to use. Partially completes #27

I did not update all locations where `board` is imported since I believe we should likely limit usages of `board` to `main` or other files that do not live in `pysquared`. Especially as we add the v5 board, I think `pysquared` will become the board independent library for satellite development. 

<img width="524" alt="Screenshot 2025-03-19 at 18 09 49" src="https://github.com/user-attachments/assets/7bf6e452-4913-40c7-beb9-fba557d9510c" />

<img width="672" alt="Screenshot 2025-03-19 at 18 09 38" src="https://github.com/user-attachments/assets/10e26cb0-89bb-47d6-ab9b-28d17721b2ec" />

## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)

Change only impacts IDE, will not run on board.