### PR TITLE
Fix json serialization error

### DIFF
--- a/lib/pysquared/hardware/digitalio.py
+++ b/lib/pysquared/hardware/digitalio.py
@@ -23,8 +23,6 @@ def initialize_pin(
     """
     logger.debug(
         message="Initializing pin",
-        pin=pin,
-        direction=direction,
         initial_value=initial_value,
     )
 

--- a/lib/pysquared/logger.py
+++ b/lib/pysquared/logger.py
@@ -83,7 +83,18 @@ class Logger:
         )
         json_order.update(kwargs)
 
-        json_output = json.dumps(json_order)
+        try:
+            json_output = json.dumps(json_order)
+        except TypeError as e:
+            json_output = json.dumps(
+                OrderedDict(
+                    [
+                        ("time", asctime),
+                        ("level", "ERROR"),
+                        ("msg", f"Failed to serialize log message: {e}"),
+                    ]
+                ),
+            )
 
         if self._can_print_this_level(level_value):
             if self.colorized:

--- a/tests/unit/lib/pysquared/test_logger.py
+++ b/tests/unit/lib/pysquared/test_logger.py
@@ -115,7 +115,14 @@ def test_critical_log(capsys, logger):
     assert '"soft": "ware"' in captured.out
     assert '"j": "20"' in captured.out
     assert '"config": "king"' in captured.out
-    assert "OSError: Manually creating an OS Error" in captured.out
+
+
+def test_type_error_log(capsys, logger):
+    logger.info("Testing type error", bad_arg=lambda x: x + 1)
+    captured = capsys.readouterr()
+    assert '"level": "ERROR"' in captured.out
+    assert "Failed to serialize log message:" in captured.out
+    assert "Object of type function is not JSON serializable" in captured.out
 
 
 def test_debug_log_color(capsys, logger_color):


### PR DESCRIPTION
## Summary

This PR solves the CircuitPython 9.2.1+ compatibility issue reported in #194. We remove the offending lines that cannot be parsed into json and gracefully catch the error in the logger

Solves #194 

## How was this tested
- [x] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
