### PR TITLE
Add spi bus init

### DIFF
--- a/lib/pysquared/hardware/busio.py
+++ b/lib/pysquared/hardware/busio.py
@@ -1,0 +1,49 @@
+from busio import SPI
+from microcontroller import Pin
+
+from lib.pysquared.hardware.decorators import with_retries
+from lib.pysquared.hardware.exception import HardwareInitializationError
+from lib.pysquared.logger import Logger
+
+try:
+    from typing import Optional
+except ImportError:
+    pass
+
+
+@with_retries(max_attempts=3, initial_delay=1)
+def initialize_spi_bus(
+    logger: Logger,
+    clock: Pin,
+    mosi: Optional[Pin] = None,
+    miso: Optional[Pin] = None,
+    baudrate: Optional[int] = 100000,
+    phase: Optional[int] = 0,
+    polarity: Optional[int] = 0,
+    bits: Optional[int] = 8,
+) -> SPI:
+    """Initializes a SPI bus"
+
+    :param Logger logger: The logger instance to log messages.
+    :param Pin clock: The pin to use for the clock signal.
+    :param Pin mosi: The pin to use for the MOSI signal.
+    :param Pin miso: The pin to use for the MISO signal.
+    :param int baudrate: The baudrate of the SPI bus (default is 100000).
+    :param int phase: The phase of the SPI bus (default is 0).
+    :param int polarity: The polarity of the SPI bus (default is 0).
+    :param int bits: The number of bits per transfer (default is 8).
+
+    :raises HardwareInitializationError: If the SPI bus fails to initialize.
+
+    :return ~busio.SPI: The initialized SPI object.
+    """
+    logger.debug("Initializing spi")
+
+    try:
+        spi = SPI(clock, mosi, miso)
+        spi.try_lock()
+        spi.configure(baudrate, phase, polarity, bits)
+        spi.unlock()
+        return spi
+    except Exception as e:
+        raise HardwareInitializationError("Failed to initialize spi") from e

--- a/lib/pysquared/hardware/digitalio.py
+++ b/lib/pysquared/hardware/digitalio.py
@@ -32,4 +32,4 @@ def initialize_pin(
         digital_in_out.value = initial_value
         return digital_in_out
     except Exception as e:
-        raise HardwareInitializationError(f"Failed to initialize pin {pin}") from e
+        raise HardwareInitializationError("Failed to initialize pin") from e

--- a/tests/unit/lib/pysquared/hardware/test_busio.py
+++ b/tests/unit/lib/pysquared/hardware/test_busio.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from microcontroller import Pin
+
+from lib.pysquared.hardware.busio import initialize_spi_bus
+from lib.pysquared.hardware.exception import HardwareInitializationError
+from lib.pysquared.logger import Logger
+
+
+@patch("lib.pysquared.hardware.busio.SPI")
+def test_initialize_spi_bus_success(mock_spi: MagicMock):
+    # Mock the logger
+    mock_logger = MagicMock(spec=Logger)
+
+    # Mock pins
+    mock_clock = MagicMock(spec=Pin)
+    mock_mosi = MagicMock(spec=Pin)
+    mock_miso = MagicMock(spec=Pin)
+
+    # Mock SPI instance
+    mock_spi_instance = mock_spi.return_value
+
+    # Test parameters
+    baudrate = 200000
+    phase = 1
+    polarity = 1
+    bits = 16
+
+    # Call fn under test
+    result = initialize_spi_bus(
+        mock_logger, mock_clock, mock_mosi, mock_miso, baudrate, phase, polarity, bits
+    )
+
+    # Assertions
+    mock_spi.assert_called_once_with(mock_clock, mock_mosi, mock_miso)
+    mock_spi_instance.try_lock.assert_called_once()
+    mock_spi_instance.configure.assert_called_once_with(baudrate, phase, polarity, bits)
+    mock_spi_instance.unlock.assert_called_once()
+    mock_logger.debug.assert_called_once()
+    assert result == mock_spi_instance
+
+
+@pytest.mark.slow
+@patch("lib.pysquared.hardware.busio.SPI")
+def test_initialize_spi_bus_failure(mock_spi: MagicMock):
+    # Mock the logger
+    mock_logger = MagicMock(spec=Logger)
+
+    # Mock pins
+    mock_clock = MagicMock(spec=Pin)
+    mock_mosi = MagicMock(spec=Pin)
+    mock_miso = MagicMock(spec=Pin)
+
+    # Mock SPI to raise an exception
+    mock_spi.side_effect = Exception("Simulated failure")
+
+    # Call the function and assert exception
+    with pytest.raises(HardwareInitializationError):
+        initialize_spi_bus(mock_logger, mock_clock, mock_mosi, mock_miso)
+
+    # Assertions
+    assert mock_spi.call_count == 3  # Called 3 times due to retries
+    mock_logger.debug.assert_called()

--- a/tests/unit/lib/pysquared/hardware/test_digitalio.py
+++ b/tests/unit/lib/pysquared/hardware/test_digitalio.py
@@ -10,7 +10,7 @@ from lib.pysquared.logger import Logger
 
 @patch("lib.pysquared.hardware.digitalio.DigitalInOut")
 @patch("lib.pysquared.hardware.digitalio.Pin")
-def test_initialize_pin_success(mock_pin: MagicMock, mock_digitial_in_out: MagicMock):
+def test_initialize_pin_success(mock_pin: MagicMock, mock_digital_in_out: MagicMock):
     # Mock the logger
     mock_logger = MagicMock(spec=Logger)
 
@@ -20,15 +20,15 @@ def test_initialize_pin_success(mock_pin: MagicMock, mock_digitial_in_out: Magic
     initial_value = True
 
     # Mock DigitalInOut instance
-    mock_digital_in_out = mock_digitial_in_out.return_value
+    mock_dio = mock_digital_in_out.return_value
 
     # Call fn under test
     _ = initialize_pin(mock_logger, mock_pin, mock_direction, initial_value)
 
     # Assertions
-    mock_digitial_in_out.assert_called_once_with(mock_pin)
-    assert mock_digital_in_out.direction == mock_direction
-    assert mock_digital_in_out.value == initial_value
+    mock_digital_in_out.assert_called_once_with(mock_pin)
+    assert mock_dio.direction == mock_direction
+    assert mock_dio.value == initial_value
     mock_logger.debug.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
Adds new spi bus initializer with retries. Fixes a few mispellings and a `pin` deserialization that would fail.

## How was this tested
- [x] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
