### PR TITLE
Added a check in the radio_manager for is_licensed

### DIFF
--- a/lib/pysquared/hardware/rfm9x/manager.py
+++ b/lib/pysquared/hardware/rfm9x/manager.py
@@ -18,10 +18,7 @@ class RFM9xManager:
     _radio: RFMSPI | None = None
 
     def __init__(
-        self,
-        logger: Logger,
-        use_fsk: Flag,
-        radio_factory: RFM9xFactory,
+        self, logger: Logger, use_fsk: Flag, radio_factory: RFM9xFactory, is_licensed
     ) -> None:
         """Initialize the rfm9x manager.
 
@@ -36,6 +33,7 @@ class RFM9xManager:
         self._log = logger
         self._use_fsk = use_fsk
         self._radio_factory = radio_factory
+        self._is_licensed = is_licensed
 
         self._radio = self.radio
 
@@ -58,7 +56,11 @@ class RFM9xManager:
     def beacon_radio_message(self, msg: Any) -> None:
         """Beacon a radio message and log the result."""
         try:
-            sent = self.radio.send(bytes(msg, "UTF-8"))
+            if self._is_licensed:
+                sent = self.radio.send(bytes(msg, "UTF-8"))
+            else:
+                sent = False
+                self._log.warning("Radio is not licensed, cannot send message")
         except Exception as e:
             self._log.error("There was an error while beaconing", e)
             return

--- a/lib/pysquared/hardware/rfm9x/manager.py
+++ b/lib/pysquared/hardware/rfm9x/manager.py
@@ -18,7 +18,11 @@ class RFM9xManager:
     _radio: RFMSPI | None = None
 
     def __init__(
-        self, logger: Logger, use_fsk: Flag, radio_factory: RFM9xFactory, is_licensed
+        self,
+        logger: Logger,
+        use_fsk: Flag,
+        radio_factory: RFM9xFactory,
+        is_licensed: bool,
     ) -> None:
         """Initialize the rfm9x manager.
 
@@ -56,11 +60,10 @@ class RFM9xManager:
     def beacon_radio_message(self, msg: Any) -> None:
         """Beacon a radio message and log the result."""
         try:
-            if self._is_licensed:
-                sent = self.radio.send(bytes(msg, "UTF-8"))
-            else:
-                sent = False
-                self._log.warning("Radio is not licensed, cannot send message")
+            if not self._is_licensed:
+                raise ValueError("Radio is not licensed")
+
+            sent = self.radio.send(bytes(msg, "UTF-8"))
         except Exception as e:
             self._log.error("There was an error while beaconing", e)
             return

--- a/main.py
+++ b/main.py
@@ -68,6 +68,7 @@ try:
             initialize_pin(logger, board.RF1_RST, digitalio.Direction.OUTPUT, True),
             config.radio,
         ),
+        config.is_licensed,
     )
 
     f = functions.functions(c, logger, config, sleep_helper, radio_manager)


### PR DESCRIPTION
## Summary
This fixes the bug outlined in #211 

## How was this tested
- [X] Added new unit tests
- [X] Ran code on hardware (screenshots are helpful)

## Example of 2 minutes of new code output
Ran on a v4c Flight Controller Board:
<details>
  <summary>
    Logs
  </summary>
 ```json

Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
{"time": "2020-01-01 01:56:30", "level": "INFO", "msg": "Booting", "published_date": "November 19, 2024", "software_version": ""}
{"time": "2020-01-01 01:56:30", "level": "INFO", "msg": "Code Starting in 5 seconds"}
{"time": "2020-01-01 01:56:31", "level": "INFO", "msg": "Code Starting in 4 seconds"}
{"time": "2020-01-01 01:56:32", "level": "INFO", "msg": "Code Starting in 3 seconds"}
{"time": "2020-01-01 01:56:33", "level": "INFO", "msg": "Code Starting in 2 seconds"}
{"time": "2020-01-01 01:56:34", "level": "INFO", "msg": "Code Starting in 1 seconds"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing Config"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Booting up!", "boot_time": "1577843795s"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "I2C0"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Hardware component not initialized", "cubesat": "Orpheus", "hardware_key": "I2C0"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "SPI0"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "I2C1"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "UART"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "IMU"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "Mag"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "RTC"}
{"time": "2020-01-01 01:56:35", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "SD Card"}
{"time": "2020-01-01 01:56:37", "level": "ERROR", "msg": "There was an error initializing this hardware component", "err": ["Traceback (most recent call last):\r\n  File \"lib/pysquared/pysquared.py\", line 77, in wrapper\r\n  File \"lib/pysquared/pysquared.py\", line 134, in init_sd_card\r\nOSError: no SD card\n"], "hardware_key": "SD Card"}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "NEOPIX"}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Initializing hardware component", "hardware_key": "TCA"}
{"time": "2020-01-01 01:56:37", "level": "ERROR", "msg": "There was an error initializing this hardware component", "err": ["Traceback (most recent call last):\r\n  File \"lib/pysquared/pysquared.py\", line 77, in wrapper\r\n  File \"lib/pysquared/pysquared.py\", line 155, in init_tca_multiplexer\r\n  File \"lib/adafruit_tca9548a.py\", line 122, in __init__\r\nValueError: No TCA9548A detected at 0x77.\n"], "hardware_key": "TCA"}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "TCA not initialized"}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "PySquared Hardware Initialization Complete!"}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "I2C0", "status": false}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Successfully initialized hardware device", "device": "SPI0", "status": true}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Successfully initialized hardware device", "device": "I2C1", "status": true}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Successfully initialized hardware device", "device": "UART", "status": true}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Successfully initialized hardware device", "device": "IMU", "status": true}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Successfully initialized hardware device", "device": "Mag", "status": true}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "SDcard", "status": false}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Successfully initialized hardware device", "device": "NEOPIX", "status": true}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "WDT", "status": false}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "TCA", "status": false}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "Face0", "status": false}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "Face1", "status": false}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "Face2", "status": false}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "Face3", "status": false}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Unable to initialize hardware device", "device": "Face4", "status": false}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Successfully initialized hardware device", "device": "RTC", "status": true}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Watchdog background task created"}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Initializing pin", "initial_value": true}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Initializing pin", "initial_value": true}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Initializing radio", "modulation": "LoRa"}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Initializing Functionalities"}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "Starting watchdog petting background task"}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Current up time stat:", "uptime": 2}
{"time": "2020-01-01 01:56:37", "level": "WARNING", "msg": "Radio is not licensed, cannot send message"}
{"time": "2020-01-01 01:56:37", "level": "INFO", "msg": "I am beaconing", "success": "False", "beacon": "KO6AZM Hello I am Orpheus! I am: normal UT:2 BN:163 EC:161 IHBPFJASTMNE! KO6AZM"}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Listening for 10 seconds"}
{"time": "2020-01-01 01:56:37", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:38", "level": "INFO", "msg": "The satellite has a super secret code!", "super_secret_code": "ABCD"}
{"time": "2020-01-01 01:56:38", "level": "DEBUG", "msg": "Listening"}
{"time": "2020-01-01 01:56:38", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:39", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:40", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:41", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:42", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:43", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:45", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:46", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:47", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:48", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:48", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:48", "level": "DEBUG", "msg": "Sleeping for 20 seconds"}
{"time": "2020-01-01 01:56:48", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:56:48", "level": "INFO", "msg": "Setting Safe Sleep Mode"}
{"time": "2020-01-01 01:57:04", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:20", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:20", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:20", "level": "ERROR", "msg": "Couldn't aquire data for the state of health: ", "err": ["Traceback (most recent call last):\r\n  File \"lib/pysquared/functions.py\", line 157, in state_of_health\r\nValueError: invalid syntax for integer with base 10\n"]}
{"time": "2020-01-01 01:57:20", "level": "WARNING", "msg": "Radio is not licensed, cannot send message"}
{"time": "2020-01-01 01:57:20", "level": "INFO", "msg": "I am beaconing", "success": "False", "beacon": "KO6AZM Yearling^2 State of Health 1/2[]KO6AZM"}
{"time": "2020-01-01 01:57:20", "level": "DEBUG", "msg": "Listening for 10 seconds"}
{"time": "2020-01-01 01:57:20", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:20", "level": "INFO", "msg": "The satellite has a super secret code!", "super_secret_code": "ABCD"}
{"time": "2020-01-01 01:57:20", "level": "DEBUG", "msg": "Listening"}
{"time": "2020-01-01 01:57:20", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:21", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:22", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:23", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:24", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:25", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:26", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:27", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:28", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:29", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:30", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:30", "level": "DEBUG", "msg": "Sleeping for 20 seconds"}
{"time": "2020-01-01 01:57:30", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:57:30", "level": "INFO", "msg": "Setting Safe Sleep Mode"}
{"time": "2020-01-01 01:57:45", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Free Memory Stat at beginning of all_face_data function", "bytes_free": 56448}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Free Memory Stat after importing Big_data library", "bytes_free": 54656}
{"time": "2020-01-01 01:58:01", "level": "ERROR", "msg": "Big_Data error", "err": ["Traceback (most recent call last):\r\n  File \"lib/pysquared/functions.py\", line 251, in all_face_data\r\nAttributeError: 'Satellite' object has no attribute 'tca'\n"]}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Sending Face Data"}
{"time": "2020-01-01 01:58:01", "level": "WARNING", "msg": "Radio is not licensed, cannot send message"}
{"time": "2020-01-01 01:58:01", "level": "INFO", "msg": "I am beaconing", "success": "False", "beacon": "KO6AZM Y-: None Y+: None X-: None X+: None  Z-: None KO6AZM"}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Listening for 10 seconds"}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:01", "level": "INFO", "msg": "The satellite has a super secret code!", "super_secret_code": "ABCD"}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Listening"}
{"time": "2020-01-01 01:58:01", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:02", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:03", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:04", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:05", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:06", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:07", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:08", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:09", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:10", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:11", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:11", "level": "DEBUG", "msg": "Sleeping for 20 seconds"}
{"time": "2020-01-01 01:58:11", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:11", "level": "INFO", "msg": "Setting Safe Sleep Mode"}
{"time": "2020-01-01 01:58:26", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:41", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:41", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:41", "level": "INFO", "msg": "Looking to get imu data..."}
{"time": "2020-01-01 01:58:41", "level": "WARNING", "msg": "Radio is not licensed, cannot send message"}
{"time": "2020-01-01 01:58:41", "level": "INFO", "msg": "I am beaconing", "success": "False", "beacon": "KO6AZM [(-0.299103, -0.0311067, 9.84168), (0.0018326, -0.0056505, -0.0190895), (141.6, 45.45, 11.55)] KO6AZM"}
{"time": "2020-01-01 01:58:41", "level": "WARNING", "msg": "Failed to send packet"}
{"time": "2020-01-01 01:58:41", "level": "DEBUG", "msg": "Listening for 10 seconds"}
{"time": "2020-01-01 01:58:41", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:41", "level": "INFO", "msg": "The satellite has a super secret code!", "super_secret_code": "ABCD"}
{"time": "2020-01-01 01:58:41", "level": "DEBUG", "msg": "Listening"}
{"time": "2020-01-01 01:58:41", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:42", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:43", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:44", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:45", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:46", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:47", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:48", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:49", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:50", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:51", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:51", "level": "DEBUG", "msg": "Sleeping for 20 seconds"}
{"time": "2020-01-01 01:58:51", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:58:51", "level": "INFO", "msg": "Setting Safe Sleep Mode"}
{"time": "2020-01-01 01:59:06", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:21", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:21", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:21", "level": "WARNING", "msg": "Radio is not licensed, cannot send message"}
{"time": "2020-01-01 01:59:21", "level": "INFO", "msg": "I am beaconing", "success": "False", "beacon": "KO6AZM Why did the sun go to school? To get a little brighter. KO6AZM"}
{"time": "2020-01-01 01:59:21", "level": "WARNING", "msg": "Failed to send packet"}
{"time": "2020-01-01 01:59:21", "level": "DEBUG", "msg": "Listening for 10 seconds"}
{"time": "2020-01-01 01:59:21", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:21", "level": "INFO", "msg": "The satellite has a super secret code!", "super_secret_code": "ABCD"}
{"time": "2020-01-01 01:59:21", "level": "DEBUG", "msg": "Listening"}
{"time": "2020-01-01 01:59:21", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:22", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:23", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:24", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:25", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:26", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:27", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:28", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:29", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:30", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:31", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:31", "level": "DEBUG", "msg": "Sleeping for 20 seconds"}
{"time": "2020-01-01 01:59:31", "level": "DEBUG", "msg": "Petting watchdog"}
{"time": "2020-01-01 01:59:31", "level": "INFO", "msg": "Setting Safe Sleep Mode"}
{"time": "2020-01-01 01:59:46", "level": "DEBUG", "msg": "Petting watchdog"}

```
</details>
