### PR TITLE
Fix modulation value retrieval in state of health logging

### DIFF
--- a/lib/pysquared/functions.py
+++ b/lib/pysquared/functions.py
@@ -154,7 +154,7 @@ class functions:
                 f"EC:{self.logger.get_error_count()}",
                 f"AB:{int(self.cubesat.f_burned.get())}",
                 f"BO:{int(self.cubesat.f_brownout.get())}",
-                f"FK:{int(self.radio_manager.get_modulation())}",
+                f"FK:{self.radio_manager.get_modulation()}",
             ]
         except Exception as e:
             self.logger.error("Couldn't aquire data for the state of health: ", e)


### PR DESCRIPTION
## Summary

The issue was that the `radio_manager.get_modulation()` can return a string literal `"LoRa"` or `"FSK"` which can't be casted into an int. I removed the int cast and that seemed to fix the issue.

## How was this tested
- [ ] Added new unit tests
- [X] Ran code on hardware (screenshots are helpful)
Here's the same code change but on my State of Health branch (so that the results are clear)
![image](https://github.com/user-attachments/assets/32d3d13b-d6f6-41fb-91cb-06dbed62aa9f)
![image](https://github.com/user-attachments/assets/9c65e66f-940c-4f2c-90c0-b0d6e8f170ca)
On this branch, you can't see the results (because they are beaconed) but the base 10 error is no longer thrown.
- [ ] Other (Please describe)
